### PR TITLE
Automated travis building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ jdk: openjdk8
 script: mvn package
 
 cache:
-  apt: true
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+
+jdk: openjdk8 
+
+script: mvn package
+
+cache:
+  apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ jdk: openjdk8
 
 script: mvn package && echo "deviation-uploader sucessfully built"
 
-cache:
-  directories:
-  - $HOME/.m2
+# cache:
+#   directories:
+#   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 jdk: openjdk8 
 
-script: mvn package
+script: mvn package && echo "deviation-uploader sucessfully built"
 
 cache:
   directories:


### PR DESCRIPTION
I leave the uploading to deviationtx.com to FDR. For reference:
Java build without cached Maven takes 13 s, with cache 11 s. Setting up and saving the cache takes again about 9 s. So for now we leave caching off.