### PR TITLE
 replace direct console writing with java.util.logging facility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+target
+local
+
+.classpath
+.project
+.settings
+
+.idea
+*.iml

--- a/README
+++ b/README
@@ -1,14 +1,39 @@
+About Deviation Uploader
+============================================================================
+
+The Deviation Uploader tools is intended to upload and download firmware
+from/to radio transmitter devices via USB by using DFuSe protocol.
+
 This code is to a large extent a direct port of the 'dfu-util' code to java.
 
 This would have been a much bigger ordeal without the work those folks have
 spent developing dfu and dfuse support.
 
-Note that this code only supports the DFuSe protocol, and onlythe Walkera
+Note that this code only supports the DFuSe protocol, and only the Walkera
 flavor of that.  It is not intended to be a generalized dfu upload/download
-tool, but instead is targetted only at communicating with Walkera transmitters.
+tool, but instead is targeted only at communicating with Walkera transmitters.
 
 
-Upgrading the jar files:
+Recommended usage
+----------------------------------------------------------------------------
+
+Deviation Uploader requires a Java 8 compatible runtime to be installed.
+Once you have downloaded the JAR file (or alternatively build your own),
+you can simply run the user interface (UI) from command line:
+
+$> java -jar DeviationUpload-0.9.0.jar
+
+There are also some command line options available.
+For more help, please run the following command:
+
+$> java -jar DeviationUpload-0.9.0.jar --help
+
+
+Development Notes
+----------------------------------------------------------------------------
+
+### Manual upgrading the jar files (when needed)
+
 download official release from:
 
 http://kayahr.github.io/usb4java/index.html and unzip
@@ -22,3 +47,24 @@ export VERSION=1.0.2; mvn install:install-file -Dfile=usb4java-1.0.0/lib/usb-api
 http://code.google.com/p/fat32-lib/
 fat32-lib:
 EXPORT VERSION=0.6.2; mvn install:install-file -Dfile=fat32-lib-$VERSION.jar -DgroupId=de-waldheinz -DartifactId=fat32-lib -Dversion=$VERSION -Dpackaging=jar -DlocalRepositoryPath=libs -DcreateChecksum=true
+
+
+### A word on application logging
+
+Deviation Uploader uses standard Java logging facilities.
+https://docs.oracle.com/javase/8/docs/api/java/util/logging/package-summary.html
+
+The Java log level are SEVERE (highest value), WARNING, INFO, CONFIG, FINE, FINER, FINEST (lowest value).
+These level should be used, in order to log information according to the users need.
+For convenient reasons, the command line options do allow a user
+to select "default", "verbose" and "extra-verbose" log level.
+The Deviation Uploader defines some mapping between this  (see LoggerConfiguration class).
+"default"       -> "INFO" and above
+"verbose"       -> "FINE" and above
+"extra-verbose" -> "FINEST" and above
+While developing, please consider, which level makes sense to use
+and what information information to show to the user.
+As a rule os thumb, "warning" and "severe" should be used in scenarios where things go wrong.
+Whereas "warning" is when something went wrong but the application can somehow recover or self-heal.
+And "severe" is typically something, which went wrong and the application can't handle
+and need to stop the requested action.

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <version>3.1</version>
     </dependency>
     <dependency>
-      <groupId>org-apache-commons</groupId>
+      <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.3-SNAPSHOT</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
 	<groupId>org.swinglabs.swingx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <modelVersion>4.0.0</modelVersion>
   <groupId>DeviationUpload</groupId>
   <artifactId>DeviationUpload</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <name>Deviation Uploader</name>
   <description>USB Uploader for Walkera DEVO
   Transmitters</description>

--- a/src/deviation/DeviationUploader.java
+++ b/src/deviation/DeviationUploader.java
@@ -3,35 +3,41 @@ package deviation;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.logging.Logger;
 
 import de.ailis.usb4java.libusb.*;
 import de.waldheinz.fs.fat.FatFileSystem;
 import de.waldheinz.fs.util.*;
 import de.waldheinz.fs.*;
 import deviation.DfuMemory.SegmentParser;
+import deviation.commandline.CommandLineHandler;
+import deviation.commandline.CliOptions;
 import deviation.filesystem.FSUtils;
 import deviation.filesystem.FileDisk2;
 import deviation.filesystem.DevoFS.DevoFSFileSystem;
 import deviation.gui.DeviationUploadGUI;
 
-import org.apache.commons.cli.*;
+import deviation.logging.LoggerConfiguration;
+
 public class DeviationUploader
 {
-    public static byte[] applyEncryption(DfuFile.ImageElement elem, TxInfo info)
+    private static final Logger LOG = Logger.getLogger(DeviationUploader.class.getName());
+
+    private static byte[] applyEncryption(DfuFile.ImageElement elem, TxInfo info)
     {
         long address = elem.address();
         byte[] data = elem.data();
         if (address < 0x08005000L && address + data.length > 0x08005000L) {
             int offset = (int)(0x08005000L - address);
             byte[] txcode = info.encodeId();
-            System.out.println("Encrypting txid for " + TxInfo.typeToString(info.type()));
+            LOG.info("Encrypting txid for " + TxInfo.typeToString(info.type()));
             for (byte b : txcode) {
                 data[offset++] = b;
             }
         }
         return data;
     }
-    public static boolean findDeviceByAddress(DfuDevice dev, int address, Integer vid, Integer pid, Integer alt)
+    private static boolean findDeviceByAddress(DfuDevice dev, int address, Integer vid, Integer pid, Integer alt)
     {
         if ((vid == null || vid == dev.idVendor()) && (pid == null || pid == dev.idProduct())) {
         	if (dev.SelectInterfaceByAddr(address, alt) != null) {
@@ -41,7 +47,7 @@ public class DeviationUploader
         return false;
     }
 
-    public static void sendDfuToDevice(DfuDevice dev, String fname, Progress progress)
+    private static void sendDfuToDevice(DfuDevice dev, String fname, Progress progress)
     {
         DfuFile file;
         try {
@@ -59,23 +65,23 @@ public class DeviationUploader
         		return;
         	}
             if (! findDeviceByAddress(dev, (int)elem.address(), file.idVendor(), file.idProduct(), elem.altSetting())) {
-                System.out.format("Error: Did not find matching device for VID:0x%x PID:0x%x alt:%d%n",
-                    file.idVendor(), file.idProduct(), elem.altSetting());
+                LOG.warning(String.format("Error: Did not find matching device for VID:0x%x PID:0x%x alt:%d",
+                    file.idVendor(), file.idProduct(), elem.altSetting()));
                 continue;
             }
             if (dev.open() != 0) {
-                System.out.println("Error: Unable to open device");
+                LOG.warning("Error: Unable to open device");
                 break;
             }
             dev.claim_and_set();
             Dfu.setIdle(dev);
             TxInfo info = dev.getTxInfo();
             if (! info.matchModel(TxInfo.getModelFromString(elem.name()))) {
-                System.out.format("Error: Dfu Tx type '%s' does not match transmitter type '%s'%n",
+                LOG.warning(String.format("Error: Dfu Tx type '%s' does not match transmitter type '%s'",
                                   TxInfo.typeToString(TxInfo.getModelFromString(elem.name())),
-                                  TxInfo.typeToString(info.type()));
-                if (TxInfo.typeToString(info.type()) == "Unknown") {
-                	System.out.format("\tTransmitter ID: '%s'\n", new String(info.getIdentifier()));
+                                  TxInfo.typeToString(info.type())));
+                if ("Unknown".equals(TxInfo.typeToString(info.type()))) {
+                	LOG.warning(String.format("Transmitter ID: '%s'", new String(info.getIdentifier())));
                 }
                 break;
             }
@@ -86,7 +92,7 @@ public class DeviationUploader
         }
     }
     
-    public static void sendBinToDevice(DfuDevice dev, String fname, int address, Integer vid, Integer pid, Integer alt, Integer iface, boolean invert)
+    private static void sendBinToDevice(DfuDevice dev, String fname, int address, Integer vid, Integer pid, Integer alt, Integer iface, boolean invert)
     {
         byte[] data;
         try {
@@ -102,13 +108,13 @@ public class DeviationUploader
     		dev.SelectInterface(dev.Interfaces().get(1));        	
         } else {
         	if (! findDeviceByAddress(dev, address, vid, pid, alt)) {
-        		System.out.format("Error: Did not find matching device for VID:0x%x PID:0x%x alt:%d%n",
-        				vid, pid, alt);
+        		LOG.warning(String.format("Error: Did not find matching device for VID:0x%x PID:0x%x alt:%d",
+        				vid, pid, alt));
         		return;
         	}
         }
         if (dev.open() != 0) {
-            System.out.println("Error: Unable to open device");
+            LOG.warning("Error: Unable to open device");
             return;
         }
         dev.claim_and_set();
@@ -120,14 +126,14 @@ public class DeviationUploader
         dev.close();
     }
 
-    public static void readBinFromDevice(DfuDevice dev, String fname, int address, Integer length, Integer vid, Integer pid, Integer alt, Integer iface, boolean invert)
+    private static void readBinFromDevice(DfuDevice dev, String fname, int address, Integer length, Integer vid, Integer pid, Integer alt, Integer iface, boolean invert)
     {
     	if (iface != null) {
     		dev.SelectInterface(dev.Interfaces().get(1));
     	} else {
     		if (! findDeviceByAddress(dev, address, vid, pid, alt)) {
-    			System.out.format("Error: Did not find matching device for VID:0x%x PID:0x%x alt:%d%n",
-    					vid, pid, alt);
+    			LOG.warning(String.format("Error: Did not find matching device for VID:0x%x PID:0x%x alt:%d",
+    					vid, pid, alt));
     			return;
     		}
     	}
@@ -135,7 +141,7 @@ public class DeviationUploader
             length = (int)dev.Memory().contiguousSize(address);
         }
         if (dev.open() != 0) {
-            System.out.println("Error: Unable to open device");
+            LOG.warning("Error: Unable to open device");
             return;
         }
         dev.claim_and_set();
@@ -160,27 +166,32 @@ public class DeviationUploader
             e.printStackTrace();
         }
     }
-    public static void listDevices(List <DfuDevice> devs)
+    private static void listDevices(List <DfuDevice> devs)
     {
-    	System.out.format("Device\t%9s %8s   %8s %7s   %s\n", "Interface", "Start", "End", "Size", "Count");
-    	for (DfuDevice dev: devs) {
-    		int i = 0;
-    		System.out.format("%s\n", dev.getTxInfo().type().getName());
-    		for (DfuInterface iface: dev.Interfaces()) {
-    			for (SegmentParser segment: iface.Memory().segments()) {
-    				for (Sector sector: segment.sectors()) {
-    					System.out.format("\t\t%d %08x   %08x %7d   %d\n",i, sector.start(), sector.end(), sector.size(), sector.count());
-    				}
-    			}
-    			i++;
-    		}
-    	}
+      if (devs.size() == 0) {
+        LOG.info("No devices found.");
+      } else {
+        LOG.info(String.format("Device\t%9s %8s   %8s %7s   %s", "Interface", "Start", "End", "Size", "Count"));
+        for (DfuDevice dev: devs) {
+          int i = 0;
+          LOG.info(String.format("%s", dev.getTxInfo().type().getName()));
+          for (DfuInterface iface: dev.Interfaces()) {
+            for (SegmentParser segment: iface.Memory().segments()) {
+              for (Sector sector: segment.sectors()) {
+                LOG.info(String.format("\t\t%d %08x   %08x %7d   %d",i, sector.start(), sector.end(), sector.size(), sector.count()));
+              }
+            }
+            i++;
+          }
+        }
+      }
     }
-    public static void resetDevices(List <DfuDevice> devs)
+
+    private static void resetDevices(List <DfuDevice> devs)
     {
     	for (DfuDevice dev: devs) {
     		if (dev.open() != 0) {
-    			System.out.println("Error: Unable to open device");
+    			LOG.warning("Error: Unable to open device");
     			break;
     		}
     		dev.claim_and_set();
@@ -190,172 +201,6 @@ public class DeviationUploader
     	}
     }
 
-    public static CommandLine handleCmdline(String[] args)
-    {
-        DeviationVersion ver = new DeviationVersion();
-        Options optionsHelp = new Options();
-        Options options = new Options();
-        OptionGroup groupCmd = new OptionGroup();
-        OptionGroup groupFile = new OptionGroup();
-        optionsHelp.addOption(Option.builder("h")
-        		                           .longOpt("help")
-                                           .desc("Show help message")
-                                           .build());
-        optionsHelp.addOption(Option.builder("V")
-        		                           .longOpt("version")
-                                           .desc("Show help message")
-                                           .build());
-
-        groupCmd.addOption(Option.builder("s")
-        		                        .longOpt("send")
-                                        .desc("send file to transmitter")
-                                        .build());
-        groupCmd.addOption(Option.builder("f")
-        		                        .longOpt("fetch")
-                                        .desc("fetch file from transmitter")
-                                        .build());
-        groupCmd.addOption(Option.builder("l")
-        		                        .longOpt("list")
-                                        .desc("list transmitter interfaces")
-                                        .build());
-        //groupCmd.setRequired(true);
-        options.addOptionGroup(groupCmd);
-        groupFile.addOption(Option.builder("d")
-        		                .longOpt("dfu")
-                                .argName( "file" )
-                                .hasArg()
-                                .desc(  "specify Dfu file to send" )
-                                .build());
-        groupFile.addOption(Option.builder("b")
-        		                .longOpt("bin")
-                                .argName( "file" )
-                                .hasArg()
-                                .desc(  "specify bin file to send/receive" )
-                                .build());
-        options.addOptionGroup(groupFile);
-        options.addOption(Option.builder("a")
-        		                .longOpt("address")
-                                .argName( "address" )
-                                .hasArg()
-                                .desc(  "specify address to send/receive from" )
-                                .build());
-        options.addOption(Option.builder()
-        		                .longOpt("overwrite")
-                                .desc(  "overwrite local files (only relevant with -fetch")
-                                .build());
-        options.addOption(Option.builder()
-        		                .longOpt("length")
-                                .argName( "bytes" )
-                                .hasArg()
-                                .desc(  "specify number of bytes to transfer" )
-                                .build());
-        options.addOption(Option.builder()
-        		                .longOpt("txid")
-                                .argName( "id" )
-                                .hasArg()
-                                .desc(  "specify the tx id as vendorid:productid" )
-                                .build());
-        options.addOption(Option.builder()
-        		                .longOpt("alt-setting")
-                                .argName( "id" )
-                                .hasArg()
-                                .desc(  "specify the alt-setting for this transfer" )
-                                .build());
-        options.addOption(Option.builder()
-        						.longOpt("interface")
-        						.argName( "interface" )
-        						.hasArg()
-        						.desc(  "manuallyoverride interface detection" )
-        						.build());
-        options.addOption(Option.builder()
-        		                .longOpt("force-txtype")
-                                .argName( "txType" )
-                                .hasArg()
-                                .desc(  "force the encryption to be to a specific transmitter type (very risky)" )
-                                .build());
-        options.addOption(Option.builder()
-        		                .longOpt("ignore-dfu-check")
-                                .desc(  "ignore Tx model checks")
-                                .build());
-        options.addOption(Option.builder()
-        						.longOpt("invert")
-        						.desc(   "invert data during bin read/write")
-        						.build());
-        options.addOption(Option.builder("h")
-        		                .longOpt("help")
-                                .desc("Show help message")
-                                .build());
-        options.addOption(Option.builder("V")
-        		                .longOpt("version")
-                                .desc("Show help message")
-                                .build());
-        options.addOption(Option.builder("r")
-                .longOpt("reset")
-                .desc("Reset after any other options have been perfomed")
-                .build());
-
-        try {
-            //Handle help and version info here
-            CommandLine cl = new DefaultParser().parse(optionsHelp, args, true);
-            if (cl.getOptions().length != 0) {
-                if (cl.hasOption("help")) {
-                    HelpFormatter formatter = new HelpFormatter();
-                    formatter.printHelp(ver.name(), options);
-                }
-                if (cl.hasOption("version")) {
-                    System.out.println(ver.name() + ": " + ver.version());
-                }
-                System.exit(0);
-            }
-            //No handle all other options
-            cl = new DefaultParser().parse(options, args);
-            if (groupCmd.getSelected() == null && ! cl.hasOption("reset")) {
-            	System.err.println("Must specify at leats one of: -s -f -l -r -h");
-            	System.exit(1);
-            }
-            String file = null;
-            if (cl.hasOption("dfu")) {
-                file = cl.getOptionValue("dfu");
-            } else if (cl.hasOption("bin")) {
-                file = cl.getOptionValue("bin");
-            }
-            if (file != null) {
-                if (cl.hasOption("fetch") && ! cl.hasOption("overwrite") && new File(file).isFile()) {
-                    System.err.println("File '" + file + "' already exists.");
-                    System.exit(1);
-                }
-                if (cl.hasOption("send") && ! new File(file).isFile()) {
-                    System.err.println("File '" + file + "' does not exist.");
-                    System.exit(1);
-                }
-                if (! cl.hasOption("address")) {
-                    if ((cl.hasOption("send") && cl.hasOption("bin")) || cl.hasOption("fetch")) {
-                        System.err.println("Must specify -address");
-                        System.exit(1);
-                    }
-                }
-            } else if(cl.hasOption("send") || cl.hasOption("fetch")) {
-                System.err.println("No file specified");
-                System.exit(1);
-            }
-            for (String opt : new String[] {"address", "length"}) {
-                if (cl.hasOption(opt)) {
-                    try {
-                        Long.decode(cl.getOptionValue(opt));
-                    } catch (NumberFormatException ex) {
-                        System.err.println("Must specify a valid numerical value to -" + opt);
-                        System.exit(1);
-                    }
-                }
-            }
-       
-            return cl;
-        } catch (ParseException ex) {
-            System.err.println(ex.getMessage());
-            System.exit(1);
-        }
-        return null;
-    }
     public static void test() {
         try {
             BlockDevice bd = new FileDisk(new File("test.fat"), false);
@@ -379,28 +224,30 @@ public class DeviationUploader
             Iterator<FsDirectoryEntry> itr = dir.iterator();
             while(itr.hasNext()) {
                 FsDirectoryEntry entry = itr.next();
-                System.out.println(entry.getName());
             }
             */
         } catch (Exception e) { e.printStackTrace();  }
         System.exit(0);
 
     }
+
     private static void test1_recur(String indent, FsDirectory dir) {
         Iterator<FsDirectoryEntry> itr = dir.iterator();
     	while(itr.hasNext()) {
     		try {
     			FsDirectoryEntry entry = itr.next();
     			if (entry.isDirectory()) {
-    				System.out.format("%sDIR: %s\n", indent, entry.getName());
+    				LOG.fine(String.format("%sDIR: %s", indent, entry.getName()));
     				test1_recur(indent + "    ", entry.getDirectory());
     			} else {
-    				System.out.format("%sFILE: %s (%d)\n", indent, entry.getName(), entry.getFile().getLength());
+    				LOG.fine(String.format("%sFILE: %s (%d)", indent, entry.getName(), entry.getFile().getLength()));
     			}
     		} catch (Exception e) { e.printStackTrace(); }
     	}
     }
-    public static void test1() {
+
+    public static void test1()
+    {
     	try {
     		FileDisk2 f = new FileDisk2(new File("test.devofs"), false, 4096);
     		DevoFSFileSystem fs = new DevoFSFileSystem(f, false);
@@ -416,68 +263,85 @@ public class DeviationUploader
     
     public static void main(String[] args)
     {
-        if (args.length == 0) {
-        	//DnDFrame.main(null);
-            DeviationUploadGUI.main(null);
-            while(true) {}
+        LoggerConfiguration.configureDefaultLogger();
+        CommandLineHandler cliHandler = new CommandLineHandler();
+        CliOptions cliOptions = cliHandler.handleCmdLine(args);
+        if (cliOptions.isVerbose()) {
+          LoggerConfiguration.configureVerboseLogger();
         }
+        if (cliOptions.isExtraVerbose()) {
+          LoggerConfiguration.configureExtraVerboseLogger();
+        }
+
+        if (!cliOptions.hasProgramOptions()) {
+          DeviationUploadGUI.main(null);
+          while(true) {}
+        }
+
         TransmitterList.init();
-        CommandLine cl = handleCmdline(args);
+
         Integer vendorId = null;
         Integer productId = null;
-        Integer altSetting = null;
-        if (cl.hasOption("txid")) {
-            String[] id = cl.getOptionValue("txid").split(":");
-            vendorId = Integer.parseInt(id[0], 16);
-            productId = Integer.parseInt(id[1], 16);
+        if (cliOptions.hasTxId()) {
+          String[] id = cliOptions.getTxIdValue().split(":");
+          vendorId = Integer.parseInt(id[0], 16);
+          productId = Integer.parseInt(id[1], 16);
         }
-        if (cl.hasOption("alt-setting")) {
-            altSetting = Integer.parseInt(cl.getOptionValue("alt-setting"));
+
+        Integer altSetting = null;
+        if (cliOptions.hasAltSettings()) {
+            altSetting = Integer.parseInt(cliOptions.getAltSettingsValue());
         }
 
         DeviceList devices = new DeviceList();
         LibUsb.init(null);
         LibUsb.getDeviceList(null, devices);
         List<DfuDevice> devs = Dfu.findDevices(devices);
+
         Integer iface = null;
-        if (cl.hasOption("interface")) {
-        	iface = Integer.parseInt(cl.getOptionValue("interface"));
+        if (cliOptions.hasInterface()) {
+        	iface = Integer.parseInt(cliOptions.getInterfaceValue());
         }
+
         for(DfuDevice dev : devs) {
         	DfuMemory mem = dev.Memory();
-        	
-            System.out.format("Found: %s [%05x:%04x] cfg=%d, intf=%d, alt=%d, name='%s'\n",
+            LOG.info(String.format("Found device: %s [%05x:%04x] cfg=%d, intf=%d, alt=%d, name='%s'",
                 dev.DFU_IFF_DFU() ? "DFU" : "Runtime",
                 dev.idVendor(),
                 dev.idProduct(),
                 dev.bConfigurationValue(),
                 dev.bInterfaceNumber(),
                 dev.bAlternateSetting(),
-                mem == null ? dev.GetId() : mem.name());
+                mem == null ? dev.GetId() : mem.name()));
             //DfuFuncDescriptor desc = new DfuFuncDescriptor(dev);
         	dev.setTxInfo(TxInfo.getTxInfo(dev));
         }
-        if (cl.hasOption("list")) {
+
+        if (cliOptions.hasList()) {
         	listDevices(devs);
         }
-        if (cl.hasOption("send")) {
-            if (cl.hasOption("dfu")) {
-                sendDfuToDevice(devs.get(0), cl.getOptionValue("dfu"), null);
+
+        if (cliOptions.hasSend()) {
+            if (cliOptions.hasDfu()) {
+                sendDfuToDevice(devs.get(0), cliOptions.getDfuValue(), null);
             } else {
-                int address = Long.decode(cl.getOptionValue("address")).intValue();
-                sendBinToDevice(devs.get(0), cl.getOptionValue("bin"), address, vendorId, productId, altSetting, iface, cl.hasOption("invert"));
+                int address = Long.decode(cliOptions.getAddressValue()).intValue();
+                sendBinToDevice(devs.get(0), cliOptions.getBinValue(), address, vendorId, productId, altSetting, iface, cliOptions.hasInvert());
             }
         }
-        if (cl.hasOption("fetch")) {
-        	String addrStr = cl.getOptionValue("address");
+
+        if (cliOptions.hasFetch()) {
+        	String addrStr = cliOptions.getAddressValue();
             int address = addrStr == null ? 0 : Long.decode(addrStr).intValue();
-        	String lenStr = cl.getOptionValue("length");
+        	String lenStr = cliOptions.getLengthValue();
             int length = lenStr == null ? 0 : Integer.decode(lenStr);
-            readBinFromDevice(devs.get(0), cl.getOptionValue("bin"), address, length, vendorId, productId, altSetting, iface, cl.hasOption("invert"));
+            readBinFromDevice(devs.get(0), cliOptions.getBinValue(), address, length, vendorId, productId, altSetting, iface, cliOptions.hasInvert());
         }
-        if (cl.hasOption("reset")) {
+
+        if (cliOptions.hasReset()) {
         	resetDevices(devs);
         }
+
         LibUsb.freeDeviceList(devices, true);
         LibUsb.exit(null);
     }

--- a/src/deviation/DfuFile.java
+++ b/src/deviation/DfuFile.java
@@ -105,7 +105,6 @@ public class DfuFile {
             for (i = 0; i < arr.length && arr[i] != 0; i++) {}
             targetName = new String(arr, 0, i);
         }
-        //System.out.println("Name: '" + targetName + "'");
         //long targetSize = ((long)(0xff & data[offset+269]) << 24)
         //                      | ((0xff & data[offset+268]) << 16)
         //                      | ((0xff & data[offset+267]) <<  8)
@@ -124,7 +123,6 @@ public class DfuFile {
                         | ((0xff & data[start+6]) << 16)
                         | ((0xff & data[start+5]) <<  8)
                         | ((0xff & data[start+4]) <<  0);
-            //System.out.format("size: %d count: %d 0x%x %d\n", targetSize, numElements, address, length);
             start += 8;
             imageElements.add(new ImageElement(targetName, bAltSetting, address, Arrays.copyOfRange(data, start, start+length)));
             start += length;

--- a/src/deviation/DfuFuncDescriptor.java
+++ b/src/deviation/DfuFuncDescriptor.java
@@ -1,12 +1,16 @@
 package deviation;
 
 import java.util.*;
+import java.util.logging.Logger;
 
 import de.ailis.usb4java.libusb.*;
 
 /* Note: This class is not functioning properly because usb4java does not properly return extra() */
 public class DfuFuncDescriptor
     {
+
+        private static final Logger LOG = Logger.getLogger(DfuFuncDescriptor.class.getName());
+
         public static final byte USB_DT_DFU =  0x21;
         public static byte [] find_descriptor(byte [] desc_list, int desc_type, int desc_index)
         {
@@ -18,7 +22,7 @@ public class DfuFuncDescriptor
     
                 desclen = 0xff & (int)desc_list[p];
                 if (desclen == 0) {
-                            System.out.println("Error: Invalid descriptor list\n");
+                            LOG.severe("Error: Invalid descriptor list");
                             return null;
                     }
                     if (desc_list[p + 1] == desc_type && hit++ == desc_index) {
@@ -51,9 +55,8 @@ public class DfuFuncDescriptor
                 //byte resbuf[] = find_descriptor(extra, USB_DT_DFU, 0);
                 if(extra != null) {
                     for (int i = 0; i < extra.length; i++) {
-                        System.out.format("%02x ", extra[i]);
+                        LOG.finest(String.format("%02x ", extra[i]));
                     }
-                    System.out.format("%n");
                 }
             }
             LibUsb.freeConfigDescriptor(cfg);

--- a/src/deviation/DfuMemory.java
+++ b/src/deviation/DfuMemory.java
@@ -1,13 +1,19 @@
 package deviation;
 
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.regex.*;
+
+import static java.util.logging.Level.FINEST;
 
 //Found DFU: [0483:df11] devnum=0, cfg=1, intf=0, alt=0, name="@Internal Flash  /0x08004000/00*002Ka,120*002Kg"
 //Found DFU: [0483:df11] devnum=0, cfg=1, intf=0, alt=1, name="@SPI Flash: Config/0x00002000/030*04Kg"
 //Found DFU: [0483:df11] devnum=0, cfg=1, intf=0, alt=2, name="@SPI Flash: Library/0x00020000/030*064Kg"
 
 public class DfuMemory {
+
+    private static Logger LOG = Logger.getLogger(DfuMemory.class.getName());
+
     public static class SegmentParser {
         private List<Sector> sectors;
 
@@ -42,9 +48,11 @@ public class DfuMemory {
                         writable = true;
                     }
                     if (size * count > 0) {
-                        //System.out.format("Sector start: 0x%x end: 0x%x size:%d count:%d %s%s%s%n",
-                        //                  address, address + size * count - 1, size, count,
-                        //                  readable ? "r" : "", erasable ? "e" : "", writable ? "w" : "");
+                        if (LOG.isLoggable(FINEST)) {
+                            LOG.finest(String.format("Sector start: 0x%x end: 0x%x size:%d count:%d %s%s%s",
+                                              address, address + size * count - 1, size, count,
+                                              readable ? "r" : "", erasable ? "e" : "", writable ? "w" : ""));
+                        }
                         sectors.add(new Sector(address, address + size * count - 1, size, count, readable, erasable, writable));
                         address += size * count;
                     }
@@ -63,7 +71,7 @@ public class DfuMemory {
         }
         String[] segmentStrings = str.split("/");
         if (segmentStrings.length < 3) {
-            System.out.format("Unexpected string: %s%n", str);
+            LOG.warning(String.format("Unexpected string: %s", str));
             throw new IllegalArgumentException("String not in correct format");
         }
         name = segmentStrings[0];

--- a/src/deviation/Transmitter.java
+++ b/src/deviation/Transmitter.java
@@ -1,11 +1,15 @@
 package deviation;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import deviation.filesystem.FSType;
 import deviation.misc.Crc;
 
 public class Transmitter {
+
+	private static final Logger LOG = Logger.getLogger(Transmitter.class.getName());
+
 	public static enum ProtoFiles {NONE, KEEP, ALL};
 	public String name;
 	public String id;
@@ -108,7 +112,7 @@ public class Transmitter {
         for (int i = 0; i < count; i++) {
             crc = Crc.Dfu32(data, crc);
         }
-        //System.out.format("Crc: 0x%x%n", crc);
+        LOG.finest(String.format("Crc: 0x%x", crc));
         return crc;
     }
 

--- a/src/deviation/TxInfo.java
+++ b/src/deviation/TxInfo.java
@@ -1,9 +1,13 @@
 package deviation;
 
 import java.util.*;
+import java.util.logging.Logger;
 
 
 public class TxInfo {
+
+    private static final Logger LOG = Logger.getLogger(TxInfo.class.getName());
+
     private String model;
     private long id1;
     private long id2;
@@ -74,7 +78,7 @@ public class TxInfo {
     {
         dev.SelectInterface(dev.Interfaces().get(0));
         if (dev.open() != 0) {
-            System.out.println("Error: Unable to open device");
+            LOG.warning("Error: Unable to open device");
             return new TxInfo();
         }
         dev.claim_and_set();

--- a/src/deviation/ZipFile.java
+++ b/src/deviation/ZipFile.java
@@ -4,10 +4,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class ZipFile {
+
+    private static final Logger LOG = Logger.getLogger(ZipFile.class.getName());
+
     String zipFile;
     List<FileInfo> files;
     public ZipFile(String fname) {
@@ -34,7 +38,7 @@ public class ZipFile {
                 }
                 ostream.flush();
                 if (ostream.size() != ze.getSize()) {
-                    System.out.format("Only read %d bytes from %s:%s (expected %d)%n", ostream.size(), zipFile, fname, ze.getSize());
+                    LOG.warning(String.format("Only read %d bytes from %s:%s (expected %d)", ostream.size(), zipFile, fname, ze.getSize()));
                 } else {
                     buffer = ostream.toByteArray();
                 }
@@ -65,7 +69,7 @@ public class ZipFile {
                  }
                  ostream.flush();
                  if (ostream.size() != ze.getSize()) {
-                     System.out.format("Only read %d bytes from %s:%s (expected %d)%n", ostream.size(), zipFile, fname, ze.getSize());
+                     LOG.warning(String.format("Only read %d bytes from %s:%s (expected %d)", ostream.size(), zipFile, fname, ze.getSize()));
                  } else {
                      buffer = ostream.toByteArray();
                  }

--- a/src/deviation/commandline/CliOptions.java
+++ b/src/deviation/commandline/CliOptions.java
@@ -1,0 +1,247 @@
+package deviation.commandline;
+
+public class CliOptions {
+
+  private boolean verbose = false;
+  private boolean extraVerbose = false;
+  private boolean programOptions = false;
+
+  private boolean txId;
+  private String txIdValue;
+  private boolean altSettings;
+  private String altSettingsValue;
+  private boolean anInterface;
+  private String interfaceValue;
+  private boolean list;
+  private boolean send;
+  private boolean dfu;
+  private String dfuValue;
+  private boolean bin;
+  private String binValue;
+  private boolean address;
+  private String addressValue;
+  private boolean length;
+  private String lengthValue;
+  private boolean fetch;
+  private String fetchValue;
+  private boolean invert;
+  private String invertValue;
+  private boolean reset;
+
+  public boolean isVerbose() {
+    return verbose;
+  }
+
+  public boolean isExtraVerbose() {
+    return extraVerbose;
+  }
+
+  public boolean hasProgramOptions() {
+    return programOptions;
+  }
+
+  public boolean hasTxId() {
+    return txId;
+  }
+
+  public String getTxIdValue() {
+    return txIdValue;
+  }
+
+  public boolean hasAltSettings() {
+    return altSettings;
+  }
+
+  public String getAltSettingsValue() {
+    return altSettingsValue;
+  }
+
+  public boolean hasInterface() {
+    return anInterface;
+  }
+
+  public String getInterfaceValue() {
+    return interfaceValue;
+  }
+
+  public boolean hasList() {
+    return list;
+  }
+
+  public boolean hasSend() {
+    return send;
+  }
+
+  public boolean hasDfu() {
+    return dfu;
+  }
+
+  public String getDfuValue() {
+    return dfuValue;
+  }
+
+  public boolean hasBin() {
+    return bin;
+  }
+
+  public String getBinValue() {
+    return binValue;
+  }
+
+  public boolean hasAddress() {
+    return address;
+  }
+
+  public String getAddressValue() {
+    return addressValue;
+  }
+
+  public boolean hasReset() {
+    return reset;
+  }
+
+  public boolean hasLength() {
+    return length;
+  }
+
+  public String getLengthValue() {
+    return lengthValue;
+  }
+
+  public boolean hasFetch() {
+    return fetch;
+  }
+
+  public String getFetchValue() {
+    return fetchValue;
+  }
+
+  public boolean hasInvert() {
+    return invert;
+  }
+
+  public String getInvertValue() {
+    return invertValue;
+  }
+
+  CliOptions setProgramOptions(boolean programOptions) {
+    this.programOptions = programOptions;
+    return this;
+  }
+
+  CliOptions setVerbose(boolean verbose) {
+    this.verbose = verbose;
+    return this;
+  }
+
+  CliOptions setExtraVerbose(boolean extraVerbose) {
+    this.extraVerbose = extraVerbose;
+    return this;
+  }
+
+  CliOptions setTxId(boolean txId) {
+    this.txId = txId;
+    return this;
+  }
+
+  CliOptions setTxIdValue(String txIdValue) {
+    this.txIdValue = txIdValue;
+    return this;
+  }
+
+  CliOptions setAltSettings(boolean altSettings) {
+    this.altSettings = altSettings;
+    return this;
+  }
+
+  CliOptions setAltSettingsValue(String altSettingsValue) {
+    this.altSettingsValue = altSettingsValue;
+    return this;
+  }
+
+  CliOptions setInterface(boolean anInterface) {
+    this.anInterface = anInterface;
+    return this;
+  }
+
+  CliOptions setInterfaceValue(String interfaceValue) {
+    this.interfaceValue = interfaceValue;
+    return this;
+  }
+
+  CliOptions setList(boolean list) {
+    this.list = list;
+    return this;
+  }
+
+  CliOptions setSend(boolean send) {
+    this.send = send;
+    return this;
+  }
+
+  CliOptions setDfu(boolean dfu) {
+    this.dfu = dfu;
+    return this;
+  }
+
+  CliOptions setDfuValue(String dfuValue) {
+    this.dfuValue = dfuValue;
+    return this;
+  }
+
+  CliOptions setBin(boolean bin) {
+    this.bin = bin;
+    return this;
+  }
+
+  CliOptions setBinValue(String binValue) {
+    this.binValue = binValue;
+    return this;
+  }
+
+  CliOptions setAddress(boolean address) {
+    this.address = address;
+    return this;
+  }
+
+  CliOptions setAddressValue(String addressValue) {
+    this.addressValue = addressValue;
+    return this;
+  }
+
+  CliOptions setLength(boolean length) {
+    this.length = length;
+    return this;
+  }
+
+  CliOptions setLengthValue(String lengthValue) {
+    this.lengthValue = lengthValue;
+    return this;
+  }
+
+  CliOptions setFetch(boolean fetch) {
+    this.fetch = fetch;
+    return this;
+  }
+
+  CliOptions setFetchValue(String fetchValue) {
+    this.fetchValue = fetchValue;
+    return this;
+  }
+
+  CliOptions setInvert(boolean invert) {
+    this.invert = invert;
+    return this;
+  }
+
+  CliOptions setInvertValue(String invertValue) {
+    this.invertValue = invertValue;
+    return this;
+  }
+
+  CliOptions setReset(boolean reset) {
+    this.reset = reset;
+    return this;
+  }
+
+}

--- a/src/deviation/commandline/CommandLineHandler.java
+++ b/src/deviation/commandline/CommandLineHandler.java
@@ -1,0 +1,262 @@
+package deviation.commandline;
+
+import deviation.DeviationVersion;
+import org.apache.commons.cli.*;
+
+import java.io.File;
+
+public class CommandLineHandler {
+
+  private static final String VERBOSE = "v";
+  private static final String EXTRA_VERBOSE = "vv";
+  private static final String TXID = "txid";
+  private static final String ALT_SETTING = "alt-setting";
+  private static final String INTERFACE = "interface";
+  private static final String LIST = "list";
+  private static final String SEND = "send";
+  private static final String DFU = "dfu";
+  private static final String BIN = "bin";
+  private static final String ADDRESS = "address";
+  private static final String LENGTH = "length";
+  private static final String FETCH = "fetch";
+  private static final String INVERT = "invert";
+  private static final String RESET = "reset";
+  private static final String OVERWRITE = "overwrite";
+  private static final String VERSION = "version";
+  private static final String HELP = "help";
+
+  private final DeviationVersion ver = new DeviationVersion();
+  private final Options optionsHelp = new Options();
+  private final Options options = new Options();
+  private final OptionGroup groupCmd = new OptionGroup();
+  private final OptionGroup groupFile = new OptionGroup();
+
+  public CommandLineHandler() {
+    configureCommandLineOptions();
+  }
+
+  public CliOptions handleCmdLine(String[] args) {
+    if (handleHelpAndVersionOptionOrDie(args)) {
+      System.exit(0);
+    };
+    CommandLine commandLine = handleRegularOptionsOrDie(args);
+    CliOptions cliOptions = new CliOptions()
+        .setVerbose(commandLine.hasOption(VERBOSE))
+        .setExtraVerbose(commandLine.hasOption(EXTRA_VERBOSE))
+        .setTxId(commandLine.hasOption(TXID))
+        .setTxIdValue(commandLine.getOptionValue(TXID))
+        .setAltSettings(commandLine.hasOption(ALT_SETTING))
+        .setAltSettingsValue(commandLine.getOptionValue(ALT_SETTING))
+        .setInterface(commandLine.hasOption(INTERFACE))
+        .setInterfaceValue(commandLine.getOptionValue(INTERFACE))
+        .setList(commandLine.hasOption(LIST))
+        .setSend(commandLine.hasOption(SEND))
+        .setDfu(commandLine.hasOption(DFU))
+        .setDfuValue(commandLine.getOptionValue(DFU))
+        .setBin(commandLine.hasOption(BIN))
+        .setBinValue(commandLine.getOptionValue(BIN))
+        .setFetch(commandLine.hasOption(FETCH))
+        .setFetchValue(commandLine.getOptionValue(FETCH))
+        .setInvert(commandLine.hasOption(INVERT))
+        .setInvertValue(commandLine.getOptionValue(INVERT))
+        .setAddress(commandLine.hasOption(ADDRESS))
+        .setAddressValue(commandLine.getOptionValue(ADDRESS))
+        .setLength(commandLine.hasOption(LENGTH))
+        .setLengthValue(commandLine.getOptionValue(LENGTH))
+        .setReset(commandLine.hasOption(RESET));
+    cliOptions.setProgramOptions(
+        cliOptions.hasTxId()
+            || cliOptions.hasAltSettings()
+            || cliOptions.hasInterface()
+            || cliOptions.hasList()
+            || cliOptions.hasSend()
+            || cliOptions.hasDfu()
+            || cliOptions.hasBin()
+            || cliOptions.hasFetch()
+            || cliOptions.hasInvert()
+            || cliOptions.hasAddress()
+            || cliOptions.hasLength()
+            || cliOptions.hasReset()
+    );
+    return cliOptions;
+  }
+
+  private void configureCommandLineOptions() {
+    optionsHelp.addOption(Option.builder("h")
+        .longOpt(HELP)
+        .desc("show help message")
+        .build());
+    optionsHelp.addOption(Option.builder("V")
+        .longOpt(VERSION)
+        .desc("show help message")
+        .build());
+
+    groupCmd.addOption(Option.builder("s")
+        .longOpt(SEND)
+        .desc("send file to transmitter")
+        .build());
+    groupCmd.addOption(Option.builder("f")
+        .longOpt(FETCH)
+        .desc("fetch file from transmitter")
+        .build());
+    groupCmd.addOption(Option.builder("l")
+        .longOpt(LIST)
+        .desc("list transmitter interfaces")
+        .build());
+    options.addOptionGroup(groupCmd);
+    groupFile.addOption(Option.builder("d")
+        .longOpt(DFU)
+        .argName("file")
+        .hasArg()
+        .desc("specify Dfu file to send")
+        .build());
+    groupFile.addOption(Option.builder("b")
+        .longOpt(BIN)
+        .argName("file")
+        .hasArg()
+        .desc("specify bin file to send/receive")
+        .build());
+    options.addOptionGroup(groupFile);
+    options.addOption(Option.builder("a")
+        .longOpt(ADDRESS)
+        .argName(ADDRESS)
+        .hasArg()
+        .desc("specify address to send/receive from. an address has to be formatted like <0x12345678>")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt(OVERWRITE)
+        .desc("overwrite local files (only relevant with -fetch")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt(LENGTH)
+        .argName("bytes")
+        .hasArg()
+        .desc("specify number of bytes to transfer")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt(TXID)
+        .argName("id")
+        .hasArg()
+        .desc("specify the tx id as <vendorid:productid>")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt(ALT_SETTING)
+        .argName("id")
+        .hasArg()
+        .desc("specify the alt-setting for this transfer")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt(INTERFACE)
+        .argName(INTERFACE)
+        .hasArg()
+        .desc("manually override interface detection")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt("force-txtype")
+        .argName("txType")
+        .hasArg()
+        .desc("force the encryption to be to a specific transmitter type (very risky)")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt("ignore-dfu-check")
+        .desc("ignore Tx model checks")
+        .build());
+    options.addOption(Option.builder()
+        .longOpt(INVERT)
+        .desc("invert data during bin read/write")
+        .build());
+    options.addOption(Option.builder("h")
+        .longOpt(HELP)
+        .desc("show help message")
+        .build());
+    options.addOption(Option.builder("V")
+        .longOpt(VERSION)
+        .desc("show program version message")
+        .build());
+    options.addOption(Option.builder("r")
+        .longOpt(RESET)
+        .desc("reset after any other options have been perfomed")
+        .build());
+    options.addOption(Option.builder(VERBOSE)
+            .longOpt("verbose")
+            .desc("verbose console logging")
+            .build());
+    options.addOption(Option.builder(EXTRA_VERBOSE)
+            .longOpt("extra-verbose")
+            .desc("extra verbose console logging")
+            .build());
+  }
+
+  private boolean handleHelpAndVersionOptionOrDie(String[] args) {
+    CommandLine cl = null;
+    try {
+      cl = new DefaultParser().parse(optionsHelp, args, true);
+    } catch (UnrecognizedOptionException e) {
+      System.err.println(e.getMessage() + "\nTry command line argument -h for help.");
+      System.exit(1);
+    } catch (ParseException e) {
+      throw new RuntimeException("Could not parse 'optionsHelp'. Aborting.", e);
+    }
+    if (cl.getOptions().length != 0) {
+      if (cl.hasOption(HELP)) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp(ver.name(), options);
+      }
+      if (cl.hasOption(VERSION)) {
+        System.out.println(ver.name() + ": " + ver.version());
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private CommandLine handleRegularOptionsOrDie(String[] args) {
+    CommandLine cl = null;
+    try {
+      cl = new DefaultParser().parse(options, args);
+    } catch (UnrecognizedOptionException e) {
+      System.err.println(e.getMessage() + "\nTry command line argument -h for help.");
+      System.exit(1);
+    } catch (ParseException e) {
+      throw new RuntimeException("Could not parse 'options'. Aborting.", e);
+    }
+
+    String file = null;
+    if (cl.hasOption(DFU)) {
+      file = cl.getOptionValue(DFU);
+    } else if (cl.hasOption(BIN)) {
+      file = cl.getOptionValue(BIN);
+    }
+    if (file != null) {
+      if (cl.hasOption(FETCH) && !cl.hasOption(OVERWRITE) && new File(file).isFile()) {
+        System.err.println("File '" + file + "' already exists.");
+        System.exit(1);
+      }
+      if (cl.hasOption(SEND) && !new File(file).isFile()) {
+        System.err.println("File '" + file + "' does not exist.");
+        System.exit(1);
+      }
+      if (!cl.hasOption(ADDRESS)) {
+        if ((cl.hasOption(SEND) && cl.hasOption(BIN)) || cl.hasOption(FETCH)) {
+          System.err.println("Must specify -address");
+          System.exit(1);
+        }
+      }
+    } else if (cl.hasOption(SEND) || cl.hasOption(FETCH)) {
+      System.err.println("No file specified");
+      System.exit(1);
+    }
+    for (String opt : new String[]{ADDRESS, LENGTH}) {
+      if (cl.hasOption(opt)) {
+        try {
+          Long.decode(cl.getOptionValue(opt));
+        } catch (NumberFormatException ex) {
+          System.err.println("Must specify a valid numerical value to -" + opt);
+          System.exit(1);
+        }
+      }
+    }
+    return cl;
+  }
+
+}

--- a/src/deviation/filesystem/DevoFS/DevoFSLayout.java
+++ b/src/deviation/filesystem/DevoFS/DevoFSLayout.java
@@ -5,10 +5,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Logger;
 
 import de.waldheinz.fs.BlockDevice;
 
 public class DevoFSLayout {
+
+	private static final Logger LOG = Logger.getLogger(DevoFSLayout.class.getName());
+
 	private BlockDevice dev;
 	private DevoFSFileSystem root;
 	private int sectorSize;
@@ -100,7 +104,7 @@ public class DevoFSLayout {
 			buf.position(buf.position() + sectorSize);
 		}
 		if (sectorHeader != START_SECTOR) {
-			System.err.format("Failed to find start sector");
+			LOG.warning("Failed to find start sector");
 			return ByteBuffer.wrap(data);
 		}
 		int start = buf.position()-1;

--- a/src/deviation/filesystem/FSUtils.java
+++ b/src/deviation/filesystem/FSUtils.java
@@ -2,6 +2,7 @@ package deviation.filesystem;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import de.waldheinz.fs.BlockDevice;
 import de.waldheinz.fs.FileSystem;
@@ -11,10 +12,12 @@ import de.waldheinz.fs.FsFile;
 import deviation.FileInfo;
 
 public class FSUtils {
+
+	private static final Logger LOG = Logger.getLogger(FSUtils.class.getName());
+
 	public static FsDirectory getFileDirectory(FileSystem fs, FileInfo file, boolean create) {
 		String[]filepath = file.name().toUpperCase().split("/");
-		//String filename = filepath[filepath.length-1];
-		
+
 		String[]filedir;
 		if (filepath.length > 1) {
 			filedir = Arrays.copyOfRange(filepath, 0, filepath.length-1);
@@ -26,7 +29,7 @@ public class FSUtils {
 		try {
 			fsdir = fs.getRoot();
 		} catch (Exception e) {
-			System.err.println("Couldn't get root dir: " + e.getMessage());
+			LOG.warning("Couldn't get root dir: " + e.getMessage());
 			return null;
 		}
         for (String subdir : filedir) {
@@ -41,7 +44,7 @@ public class FSUtils {
             		}
             		fs_entry = fsdir.addDirectory(subdir);
             		if (fs_entry == null) {
-            			System.err.println("Couldn't create directory '" + subdir);
+            			LOG.warning("Couldn't create directory '" + subdir);
             			return null;
             		}
             		fs_entry.setLastModified(0); //Directories get an epoch date
@@ -72,12 +75,12 @@ public class FSUtils {
 				}
 				fs_entry = fsdir.addFile(filename);
 				if (fs_entry == null) {
-					System.err.println("Failed to create file '" + file.name());
+					LOG.severe("Failed to create file '" + file.name());
 					return;
 				}
 			}
 			if (! fs_entry.isFile()) {
-				System.err.println(file.name() + " exists but is not a file");
+				LOG.severe(file.name() + " exists but is not a file");
 				return;
 			}
 			if (file.deleted()) {

--- a/src/deviation/filesystem/FileDisk2.java
+++ b/src/deviation/filesystem/FileDisk2.java
@@ -62,7 +62,7 @@ public final class FileDisk2 implements BlockDevice {
      */
     public FileDisk2(File file, boolean readOnly, int bytesPerSector, double bytesPerSec) throws FileNotFoundException {
     	BYTES_PER_SECTOR = bytesPerSector;
-        if (!file.exists()) throw new FileNotFoundException();
+        if (!file.exists()) throw new FileNotFoundException("File '" + file + "' does not exist.");
 
         this.readOnly = readOnly;
         this.closed = false;

--- a/src/deviation/filesystem/TxInterfaceCommon.java
+++ b/src/deviation/filesystem/TxInterfaceCommon.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Logger;
 
 import de.waldheinz.fs.FileSystem;
 import de.waldheinz.fs.FsDirectory;
@@ -11,6 +12,9 @@ import de.waldheinz.fs.FsDirectoryEntry;
 import deviation.FileInfo;
 
 public class TxInterfaceCommon {
+
+	  private static final Logger LOG = Logger.getLogger(TxInterfaceCommon.class.getName());
+
     protected static List<FileInfo> readDirRecur(String parent, FsDirectory dir) throws IOException {
     	List <FileInfo>files = new ArrayList<FileInfo>();
         Iterator<FsDirectoryEntry> itr = dir.iterator();
@@ -19,11 +23,11 @@ public class TxInterfaceCommon {
     		if (entry.isDirectory()) {
     			if (entry.getName().equals(".") || entry.getName().equals(".."))
     				continue;
-    			System.out.format("DIR: %s\n", entry.getName());
+    			LOG.fine(String.format("DIR: %s", entry.getName()));
     			files.addAll(readDirRecur(parent + entry.getName() + "/", entry.getDirectory()));
     		} else {
     			files.add(new FileInfo(parent + entry.getName(), (int)entry.getFile().getLength()));
-    			System.out.format("FILE: %s (%d)\n", entry.getName(), entry.getFile().getLength());
+					LOG.fine(String.format("FILE: %s (%d)", entry.getName(), entry.getFile().getLength()));
     		}
     	}
     	return files;
@@ -41,7 +45,7 @@ public class TxInterfaceCommon {
         	Iterator<FsDirectoryEntry> itr = dir.iterator();
         	while(itr.hasNext()) {
         		FsDirectoryEntry entry = itr.next();
-        		System.out.println(entry.getName());
+        		LOG.info(entry.getName());
         	}
         } catch (IOException e) { e.printStackTrace(); }
     }

--- a/src/deviation/filesystem/TxInterfaceEmulator.java
+++ b/src/deviation/filesystem/TxInterfaceEmulator.java
@@ -1,9 +1,11 @@
 package deviation.filesystem;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import de.waldheinz.fs.FileSystem;
 import de.waldheinz.fs.FsDirectory;
@@ -17,6 +19,10 @@ import deviation.TransmitterList;
 import deviation.TxInfo;
 
 public class TxInterfaceEmulator extends TxInterfaceCommon implements TxInterface {
+
+	private static final Logger LOG = Logger.getLogger(TxInterfaceEmulator.class.getName());
+	private static final String TEST_FAT_FILE = "test.fat";
+
 	//private Progress progress;
 	private FileSystem fs;
 	private FileDisk2 blockDev;
@@ -24,9 +30,11 @@ public class TxInterfaceEmulator extends TxInterfaceCommon implements TxInterfac
 	private static final String emulatedTx = "Devo 7e";
 	public TxInterfaceEmulator() {
 		try {
-			blockDev = new FileDisk2(new File("test.fat"), false, 4096, 5000);
+			blockDev = new FileDisk2(new File(TEST_FAT_FILE), false, 4096, 5000);
 			tx = TransmitterList.get(emulatedTx);
-		} catch (Exception e) { e.printStackTrace(); }
+		} catch (FileNotFoundException e) {
+			LOG.fine(TEST_FAT_FILE + " file not found. Continue without.");
+		}
 	}
     public void setProgress(Progress progress) { /*this.progress = progress; */}
     public DfuDevice getDevice() { return null; }

--- a/src/deviation/filesystem/TxInterfaceUSB.java
+++ b/src/deviation/filesystem/TxInterfaceUSB.java
@@ -3,6 +3,7 @@ package deviation.filesystem;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import de.waldheinz.fs.FileSystem;
 import de.waldheinz.fs.FsDirectory;
@@ -18,6 +19,9 @@ import deviation.TxInfo;
 import deviation.filesystem.DevoFS.DevoFSFileSystem;
 
 public class TxInterfaceUSB extends TxInterfaceCommon implements TxInterface  {
+
+	  private static final Logger LOG = Logger.getLogger(TxInterfaceUSB.class.getName());
+
     DfuDevice dev;
     FlashIO rootBlockDev;
     FlashIO mediaBlockDev;
@@ -46,7 +50,7 @@ public class TxInterfaceUSB extends TxInterfaceCommon implements TxInterface  {
         }
 		rootIface = dev.SelectInterfaceByAddr(tx.getRootSectorOffset() * SECTOR_SIZE);
 		if (rootIface == null) {
-			System.out.println("Could not identify any memory region for rootFS");
+			LOG.info("Could not identify any memory region for rootFS");
 		}
         rootBlockDev = new FlashIO(dev, tx.getRootSectorOffset() * SECTOR_SIZE, tx.isRootInverted(), SECTOR_SIZE, null);
     	
@@ -146,7 +150,7 @@ public class TxInterfaceUSB extends TxInterfaceCommon implements TxInterface  {
     }
     public void open() {
 		if (dev.open() != 0) {
-			System.out.println("Error: Unable to open device");
+			LOG.severe("Error: Unable to open device");
 			return;
 		}
 		dev.claim_and_set();    	
@@ -206,14 +210,14 @@ public class TxInterfaceUSB extends TxInterfaceCommon implements TxInterface  {
         	try {
         		has_media = DetectFS(FSStatus.MEDIA_FS);
         	} catch (Exception e){
-        		System.out.println("Error: Unable to open media device");
+        		LOG.severe("Error: Unable to open media device");
         		return FSStatus.unformatted();
         	}
         }
        	try {
        		has_root = DetectFS(FSStatus.ROOT_FS);
        	} catch (Exception e){
-       		System.out.println("Error: Unable to open root device");
+					LOG.severe("Error: Unable to open root device");
     		return FSStatus.unformatted();
        	}
         //IOUtil.writeFile("fatroot", fatRootBytes);

--- a/src/deviation/gui/DeviationUploadGUI.java
+++ b/src/deviation/gui/DeviationUploadGUI.java
@@ -203,7 +203,6 @@ public class DeviationUploadGUI {
         tabbedPane.addChangeListener(new ChangeListener() {
         	public void stateChanged(ChangeEvent e) {
         		int index = tabbedPane.getSelectedIndex();
-        		System.out.println("Tab: " + index);
         		if (index == FILEMGR_TAB) {
         			FileMgrPanel.updateFileList();
         		}

--- a/src/deviation/gui/DfuSendTab.java
+++ b/src/deviation/gui/DfuSendTab.java
@@ -8,6 +8,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
@@ -20,9 +21,9 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import deviation.*;
 
 public class DfuSendTab extends JPanel {
-    /**
-     * 
-     */
+
+    private static final Logger LOG = Logger.getLogger(DfuSendTab.class.getName());
+
     private static final long serialVersionUID = 1L;
     private static final String DEFAULT_DIR = "DefaultDir";
     private JTextField DFU_txtFile;
@@ -137,9 +138,9 @@ public class DfuSendTab extends JPanel {
                         fileList.setTotalBytes(size);
                     } else{
                         DFU_btnSend.setEnabled(false);
-                        System.out.format("Error: Dfu Tx type '%s' does not match transmitter type '%s'%n",
+                        LOG.severe(String.format("Error: Dfu Tx type '%s' does not match transmitter type '%s'",
                                 TxInfo.typeToString(type),
-                                TxInfo.typeToString(gui.getTxInfo().type()));
+                                TxInfo.typeToString(gui.getTxInfo().type())));
                     }
                 } catch (IOException ex) {
                     ex.printStackTrace();

--- a/src/deviation/gui/FileMgrDragDrop.java
+++ b/src/deviation/gui/FileMgrDragDrop.java
@@ -158,7 +158,6 @@ public class FileMgrDragDrop {
 							files.add(f);
 						} catch (Exception e) {e.printStackTrace(); }
 					}
-					//System.out.println(node.getClass().getName() + " " + node);
 				}
 				return new FileTransferable(files);
 			}

--- a/src/deviation/gui/FileMgrTab.java
+++ b/src/deviation/gui/FileMgrTab.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -37,6 +38,9 @@ import deviation.filesystem.TxInterface;
 import deviation.gui.treemodel.FilesToSendModel;
 
 public class FileMgrTab extends JPanel {
+
+	private static final Logger LOG = Logger.getLogger(FileMgrTab.class.getName());
+
 	private static final long serialVersionUID = 1L;
     private static final String LIBPATH_DIR = "LibPathDir";
     private static final String SHOWSYNC = "ShowSyncDlg";
@@ -154,9 +158,9 @@ public class FileMgrTab extends JPanel {
 					} catch (Exception e) { e.printStackTrace(); }
 					List <FileInfo> files = fs.readAllDirs();
 					fs.close();
-					System.out.format("Count: %d\n", files.size());
+					LOG.info(String.format("Count: %d", files.size()));
 					for (FileInfo file: files) {
-						System.out.println("FILE: " + file.name());
+						LOG.info("FILE: " + file.name());
 					}
 					return files;
 				}
@@ -311,7 +315,7 @@ public class FileMgrTab extends JPanel {
 			final Object obj = txTree.getPathForRow(rowIndex).getLastPathComponent();
 			if (obj instanceof FileInfo) {
 				final FileInfo fileinfo = (FileInfo)obj;
-				System.out.format("Double click on: %s\n", fileinfo.name());
+				LOG.finest("Double click on: " + fileinfo.name());
 				SwingWorker<FileInfo, Object> process;
 				process = new SwingWorker<FileInfo, Object>() {
 					protected void done() {

--- a/src/deviation/gui/InstallTab.java
+++ b/src/deviation/gui/InstallTab.java
@@ -424,10 +424,6 @@ public class InstallTab extends JPanel {
                 zipFiles.AddFile(fname);
                 txtField.setText(fname);
                 parseZipFiles();
-//                } catch (IOException ex) {
-//                    System.err.println("Caught IOException: " + ex.getMessage());
-//                }
-
             }
         }
     }

--- a/src/deviation/gui/InstallTabOptList.java
+++ b/src/deviation/gui/InstallTabOptList.java
@@ -186,7 +186,6 @@ public class InstallTabOptList extends JScrollPane {
     	}
 //    	ShowAdvanced();
     	if (combobox.getSelectedIndex() != 4) {
-    		System.out.println("Here");
     		ShowAutomatic();
     	} else {
     		ShowAdvanced();

--- a/src/deviation/gui/MonitorUSB.java
+++ b/src/deviation/gui/MonitorUSB.java
@@ -1,6 +1,7 @@
 package deviation.gui;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import javax.swing.SwingWorker;
 
@@ -12,6 +13,8 @@ import deviation.TxInfo;
 
 //This will execute in the Swing Event thread
 public class MonitorUSB extends SwingWorker<String, DfuDevice> {
+
+	  private static final Logger LOG = Logger.getLogger(MonitorUSB.class.getName());
 
     String strObject;
     DeviceList devices;
@@ -56,7 +59,7 @@ public class MonitorUSB extends SwingWorker<String, DfuDevice> {
     					if (dfuDev != null) {
     						LibUsb.freeDeviceList(this.devices, true);
     						dfuDev = null;
-    						System.out.println("Unplug detected");
+    						LOG.info("Unplug detected");
     						state_changed = true;
     						//Signal disconnect
     					}
@@ -68,7 +71,7 @@ public class MonitorUSB extends SwingWorker<String, DfuDevice> {
     						dfuDev = dev;
     						dfuDev.setTxInfo(TxInfo.getTxInfo(dfuDev));
     						this.devices = devices;
-    						System.out.println("Hotplug detected");
+								LOG.info("Hotplug detected");
     						state_changed = true;
     						//Signal connect/change
     					} else {

--- a/src/deviation/gui/TextEditor.java
+++ b/src/deviation/gui/TextEditor.java
@@ -3,12 +3,12 @@ package deviation.gui;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.event.*;
+import java.util.logging.Logger;
 
 import javax.swing.*;
 import javax.swing.text.BadLocationException;
 
 import org.fife.rsta.ui.CollapsibleSectionPanel;
-//import org.fife.rsta.ui.DocumentMap;
 import org.fife.rsta.ui.GoToDialog;
 import org.fife.rsta.ui.SizeGripIcon;
 import org.fife.rsta.ui.search.FindDialog;
@@ -37,6 +37,8 @@ import deviation.FileInfo;
  * @version 1.0
  */
 public class TextEditor extends JDialog implements SearchListener {
+
+	private static final Logger LOG = Logger.getLogger(TextEditor.class.getName());
 
 	private static final long serialVersionUID = 1L;
 	private CollapsibleSectionPanel csp;
@@ -71,7 +73,7 @@ public class TextEditor extends JDialog implements SearchListener {
 		textArea.setMarkOccurrences(true);
 		textArea.append(finalData);
 		Font f = textArea.getFont();
-		System.out.format("Font: %d", f.getSize());
+		LOG.info(String.format("Font: %d", f.getSize()));
 		f = new Font(f.getFamily(), f.getStyle(), f.getSize()+5);
 		textArea.setFont(f);
 		RTextScrollPane sp = new RTextScrollPane(textArea);

--- a/src/deviation/gui/treemodel/FilesToSendModel.java
+++ b/src/deviation/gui/treemodel/FilesToSendModel.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.logging.Logger;
 
 
 import org.jdesktop.swingx.treetable.AbstractTreeTableModel;
@@ -12,6 +13,9 @@ import deviation.FileInfo;
 import deviation.gui.FilesToSend;
 
 public class FilesToSendModel extends AbstractTreeTableModel {
+
+	private final static Logger LOG = Logger.getLogger(FilesToSendModel.class.getName());
+
 	private final static String[] COLUMN_NAMES = {"Name", "Size"};
 	List<FileInfo> files;
 	
@@ -26,7 +30,7 @@ public class FilesToSendModel extends AbstractTreeTableModel {
 	}
 	public List <FileInfo> getFiles() { return files; }
 	public void refresh() {
-		System.out.println("Firing Root");
+		LOG.finest("Firing Root");
 		super.modelSupport.fireNewRoot();
 	}
 	public void update(List<FileInfo> files) {
@@ -101,7 +105,6 @@ public class FilesToSendModel extends AbstractTreeTableModel {
     public int getChildCount(Object parent) {
     	String dir = (parent instanceof String) ? (String)parent : "";
     	List<Object> entries = getDirList(dir);
-    	//System.out.format("getChildCount for '%s' returned %d\n", dir, entries.size());
     	return entries.size();
     }
 

--- a/src/deviation/logging/DeviationLogFormatter.java
+++ b/src/deviation/logging/DeviationLogFormatter.java
@@ -1,0 +1,60 @@
+package deviation.logging;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.logging.LogRecord;
+
+/**
+ * Overrides {@link java.util.logging.SimpleFormatter}
+ * in order to use international string formatting
+ * and using a single line default formatting string
+ */
+class DeviationLogFormatter extends java.util.logging.SimpleFormatter {
+
+  private static final String LOG_FORMAT = "[%1$tFT%1$tT.%1$tL%1$tz] (%4$s) %3$s: %5$s%6$s%n";
+
+  public synchronized String format(LogRecord record) {
+    String source;
+    if (record.getSourceClassName() != null) {
+      source = record.getSourceClassName();
+      if (record.getSourceMethodName() != null) {
+        source += " " + record.getSourceMethodName();
+      }
+    } else {
+      source = record.getLoggerName();
+    }
+    String throwable = "";
+    if (record.getThrown() != null) {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      pw.println();
+      record.getThrown().printStackTrace(pw);
+      pw.close();
+      throwable = sw.toString();
+    }
+    return String.format(LOG_FORMAT,
+        new Date(record.getMillis()),
+        source,
+        makeSimplyfiedName(record),
+        record.getLevel().getName(),
+        formatMessage(record),
+        throwable);
+  }
+
+  private String makeSimplyfiedName(LogRecord record) {
+    String name = record.getLoggerName();
+    if (name != null) {
+      String[] parts = name.split("[.]");
+      for (int i = 0; i < parts.length; i++) {
+        if (i < parts.length - 1) {
+          parts[i] = (parts[i].length() > 1) ? parts[i].substring(0, 1) : parts[i];
+        }
+      }
+      name = StringUtils.join(parts, '.');
+    }
+    return name;
+  }
+}

--- a/src/deviation/logging/LoggerConfiguration.java
+++ b/src/deviation/logging/LoggerConfiguration.java
@@ -1,0 +1,50 @@
+package deviation.logging;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.*;
+
+public class LoggerConfiguration {
+
+  public static void configureDefaultLogger() {
+    configureLogger(INFO);
+  }
+
+  public static void configureVerboseLogger() {
+    configureLogger(FINE);
+  }
+
+  public static void configureExtraVerboseLogger() {
+    configureLogger(FINEST);
+  }
+
+  private static void configureLogger(Level level) {
+    removeAllRootLogger();
+    Logger deviationLogger = Logger.getLogger("deviation");
+    removeExistingHandlers(deviationLogger);
+    deviationLogger.addHandler(createConsoleHandler());
+    deviationLogger.setLevel(level);
+  }
+
+  private static void removeAllRootLogger() {
+    Logger logger = Logger.getLogger("");
+    removeExistingHandlers(logger);
+  }
+
+  private static ConsoleHandler createConsoleHandler() {
+    ConsoleHandler consoleHandler = new ConsoleHandler();
+    consoleHandler.setFormatter(new DeviationLogFormatter());
+    consoleHandler.setLevel(ALL);
+    return consoleHandler;
+  }
+
+  private static void removeExistingHandlers(Logger logger) {
+    for (Handler h : logger.getHandlers()) {
+      logger.removeHandler(h);
+    }
+  }
+
+}


### PR DESCRIPTION

Summary
-----------------
This PR is intended to replace the current direct console (STDOUT) writing
of the application with proper logging facilites, based on java.util.logging.

Any feddback is welcome.

Tension/Reason
-----------------
While I was using the Deviation Uploader 0.9.0, I was irritated by various
messages in the terminal (I did run via 'java -jar ...' command).
There where messages like "here" or "tab index 1" and also some stack traces occur.
Clearly, some of these where leftovers from some debugging sessions.
Hence, I thought it would be usefull to have proper logging in place,
which also offers some "verbose" option, for more technical skilled users.
And like with any proper logging, there should be a systematic incl. time stamps,
which would allow users, to give good error reports to report back some issues.

Brief summary of changes
-------------------------------
* add .gitignore to ignore Eclipse and IntelliJ project files
* replace SNAPSHOT and switch to latest stable release Apache Commons CLI version 1.4
* replace all System.(out|err).(println|format) invocations with LOG.xxx method calls
* introduce two new command line switches '--verbose' and '--extra-verbose'.
* remove some comments (read as dead code).
* refactor commmand line parsing into separate class CommandLineHandler
* add documentation about logging into README
* fix some typos in source, comments, messages and README