### PR TITLE
move tests into its own test folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,22 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     	<artifactId>yamlbeans</artifactId>
     	<version>1.09</version>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.9.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-assert</artifactId>
+      <version>1.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>
+    <testSourceDirectory>test</testSourceDirectory>
     <resources>
       <resource>
         <directory>src/deviation/resources</directory>

--- a/src/deviation/DeviationUploader.java
+++ b/src/deviation/DeviationUploader.java
@@ -358,64 +358,7 @@ public class DeviationUploader
         }
         return null;
     }
-    public static void test() {
-        try {
-            BlockDevice bd = new FileDisk(new File("test.fat"), false);
-            FileSystem fs = FatFileSystem.read(bd, false);
-            FileGroup zips = new FileGroup();
-            zips.AddFile("test.zip");
-            for (FileInfo file: zips.GetFilesystemFiles()) {
-            	FSUtils.copyFile(fs, file);
-            }
-            fs.close();
-            bd.close();
-            /*
-            String[]dirs = "/media/".split("/");
-            FsDirectory dir = fs.getRoot();
-            for (String subdir : dirs) {
-                if (subdir.equals("")) {
-                   continue;
-                }
-                dir = dir.getEntry(subdir).getDirectory();
-            }
-            Iterator<FsDirectoryEntry> itr = dir.iterator();
-            while(itr.hasNext()) {
-                FsDirectoryEntry entry = itr.next();
-                System.out.println(entry.getName());
-            }
-            */
-        } catch (Exception e) { e.printStackTrace();  }
-        System.exit(0);
 
-    }
-    private static void test1_recur(String indent, FsDirectory dir) {
-        Iterator<FsDirectoryEntry> itr = dir.iterator();
-    	while(itr.hasNext()) {
-    		try {
-    			FsDirectoryEntry entry = itr.next();
-    			if (entry.isDirectory()) {
-    				System.out.format("%sDIR: %s\n", indent, entry.getName());
-    				test1_recur(indent + "    ", entry.getDirectory());
-    			} else {
-    				System.out.format("%sFILE: %s (%d)\n", indent, entry.getName(), entry.getFile().getLength());
-    			}
-    		} catch (Exception e) { e.printStackTrace(); }
-    	}
-    }
-    public static void test1() {
-    	try {
-    		FileDisk2 f = new FileDisk2(new File("test.devofs"), false, 4096);
-    		DevoFSFileSystem fs = new DevoFSFileSystem(f, false);
-            FsDirectory dir = fs.getRoot();
-            test1_recur("", dir);
-            ByteBuffer dest = ByteBuffer.allocate((int)f.getSize());
-            Arrays.fill(dest.array(), (byte)0);
-            f.write(0, dest);
-            fs.close();
-    	} catch (Exception e) { e.printStackTrace(); }    
-     	System.exit(0);
-    }
-    
     public static void main(String[] args)
     {
         if (args.length == 0) {

--- a/src/deviation/DeviationUploader.java
+++ b/src/deviation/DeviationUploader.java
@@ -1,22 +1,17 @@
 package deviation;
 
-import java.io.*;
-import java.nio.ByteBuffer;
-import java.util.*;
-
-import de.ailis.usb4java.libusb.*;
-import de.waldheinz.fs.fat.FatFileSystem;
-import de.waldheinz.fs.util.*;
-import de.waldheinz.fs.*;
+import de.ailis.usb4java.libusb.DeviceList;
+import de.ailis.usb4java.libusb.LibUsb;
 import deviation.DfuMemory.SegmentParser;
 import deviation.commandline.CliOptions;
 import deviation.commandline.CommandLineHandler;
 import deviation.filesystem.FSUtils;
-import deviation.filesystem.FileDisk2;
-import deviation.filesystem.DevoFS.DevoFSFileSystem;
 import deviation.gui.DeviationUploadGUI;
 
-import org.apache.commons.cli.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
 public class DeviationUploader
 {
     public static byte[] applyEncryption(DfuFile.ImageElement elem, TxInfo info)
@@ -193,35 +188,6 @@ public class DeviationUploader
     		dev.close();
     	}
     }
-
-    public static void test() {
-        try {
-            BlockDevice bd = new FileDisk(new File("test.fat"), false);
-            FileSystem fs = FatFileSystem.read(bd, false);
-            FileGroup zips = new FileGroup();
-            zips.AddFile("test.zip");
-            for (FileInfo file: zips.GetFilesystemFiles()) {
-            	FSUtils.copyFile(fs, file);
-            }
-            fs.close();
-            bd.close();
-            /*
-            String[]dirs = "/media/".split("/");
-            FsDirectory dir = fs.getRoot();
-            for (String subdir : dirs) {
-                if (subdir.equals("")) {
-                   continue;
-                }
-                dir = dir.getEntry(subdir).getDirectory();
-            }
-            Iterator<FsDirectoryEntry> itr = dir.iterator();
-            while(itr.hasNext()) {
-                FsDirectoryEntry entry = itr.next();
-                System.out.println(entry.getName());
-            }
-            */
-        } catch (Exception e) { e.printStackTrace();  }
-        System.exit(0);
 
     public static void main(String[] args)
     {

--- a/test/deviation/DeviationUploaderTest.java
+++ b/test/deviation/DeviationUploaderTest.java
@@ -1,0 +1,92 @@
+package deviation;
+
+import de.waldheinz.fs.BlockDevice;
+import de.waldheinz.fs.FileSystem;
+import de.waldheinz.fs.FsDirectory;
+import de.waldheinz.fs.FsDirectoryEntry;
+import de.waldheinz.fs.fat.FatFileSystem;
+import de.waldheinz.fs.util.FileDisk;
+import deviation.filesystem.DevoFS.DevoFSFileSystem;
+import deviation.filesystem.FSUtils;
+import deviation.filesystem.FileDisk2;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.testng.Assert.*;
+
+public class DeviationUploaderTest {
+
+    @Test
+    public void an_exsample_test_current_dir_contains_files() {
+        File currentDir = new File(".");
+        File[] files = currentDir.listFiles();
+
+        assertThat(files).isNotNull();
+        assertThat(files.length).isGreaterThan(0);
+    }
+
+    public void test() throws Exception {
+        BlockDevice bd = new FileDisk(new File("test.fat"), false);
+        FileSystem fs = FatFileSystem.read(bd, false);
+        FileGroup zips = new FileGroup();
+        zips.AddFile("test.zip");
+        for (FileInfo file : zips.GetFilesystemFiles()) {
+            FSUtils.copyFile(fs, file);
+        }
+        fs.close();
+        bd.close();
+            /*
+            String[]dirs = "/media/".split("/");
+            FsDirectory dir = fs.getRoot();
+            for (String subdir : dirs) {
+                if (subdir.equals("")) {
+                   continue;
+                }
+                dir = dir.getEntry(subdir).getDirectory();
+            }
+            Iterator<FsDirectoryEntry> itr = dir.iterator();
+            while(itr.hasNext()) {
+                FsDirectoryEntry entry = itr.next();
+                System.out.println(entry.getName());
+            }
+            */
+    }
+
+
+    private void test1_recur(String indent, FsDirectory dir) {
+        Iterator<FsDirectoryEntry> itr = dir.iterator();
+        while (itr.hasNext()) {
+            try {
+                FsDirectoryEntry entry = itr.next();
+                if (entry.isDirectory()) {
+                    System.out.format("%sDIR: %s\n", indent, entry.getName());
+                    test1_recur(indent + "    ", entry.getDirectory());
+                } else {
+                    System.out.format("%sFILE: %s (%d)\n", indent, entry.getName(), entry.getFile().getLength());
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void test1() throws Exception {
+
+        FileDisk2 f = new FileDisk2(new File("test.devofs"), false, 4096);
+        DevoFSFileSystem fs = new DevoFSFileSystem(f, false);
+        FsDirectory dir = fs.getRoot();
+        test1_recur("", dir);
+        ByteBuffer dest = ByteBuffer.allocate((int) f.getSize());
+        Arrays.fill(dest.array(), (byte) 0);
+        f.write(0, dest);
+        fs.close();
+
+    }
+
+
+}


### PR DESCRIPTION
its common practive to have test code in separate folder in Java projects.
Maven supports that practice excellently.

I did add a simple test case with proper assertions, to outline its usage.

this is a proposal, how tests can be isolated from production code.

simply run ```mvn test``` to fire the whole test suite at once