### PR TITLE
Rejuvenate logging statement levels

### DIFF
--- a/src/deviation/DeviationUploader.java
+++ b/src/deviation/DeviationUploader.java
@@ -27,7 +27,7 @@ public class DeviationUploader
             int offset = (int)(0x08005000L - address);
             byte[] txcode = info.encodeId();
             if (txcode != null) {
-                LOG.info("Encrypting txid for " + TxInfo.typeToString(info.type()));
+                LOG.finest("Encrypting txid for " + TxInfo.typeToString(info.type()));
                 for (byte b : txcode) {
                     data[offset++] = b;
                 }
@@ -167,16 +167,16 @@ public class DeviationUploader
     private static void listDevices(List <DfuDevice> devs)
     {
       if (devs.size() == 0) {
-        LOG.info("No devices found.");
+        LOG.finest("No devices found.");
       } else {
-        LOG.info(String.format("Device\t%9s %8s   %8s %7s   %s", "Interface", "Start", "End", "Size", "Count"));
+        LOG.finest(String.format("Device\t%9s %8s   %8s %7s   %s", "Interface", "Start", "End", "Size", "Count"));
         for (DfuDevice dev: devs) {
           int i = 0;
-          LOG.info(String.format("%s", dev.getTxInfo().type().getName()));
+          LOG.finest(String.format("%s", dev.getTxInfo().type().getName()));
           for (DfuInterface iface: dev.Interfaces()) {
             for (SegmentParser segment: iface.Memory().segments()) {
               for (Sector sector: segment.sectors()) {
-                LOG.info(String.format("\t\t%d %08x   %08x %7d   %d",i, sector.start(), sector.end(), sector.size(), sector.count()));
+                LOG.finest(String.format("\t\t%d %08x   %08x %7d   %d",i, sector.start(), sector.end(), sector.size(), sector.count()));
               }
             }
             i++;

--- a/src/deviation/Dfu.java
+++ b/src/deviation/Dfu.java
@@ -113,7 +113,7 @@ public final class Dfu
                            address & ~(sector.size() - 1)));
             buf[0] = 0x41;  // Erase command
         } else if (command == DFUSE_SET_ADDRESS) {
-            LOG.info(String.format("Setting address pointer to 0x%x", address));
+            LOG.fine(String.format("Setting address pointer to 0x%x", address));
             buf[0] = 0x21;  /* Set Address Pointer command */
         } else {
             LOG.severe(String.format("Error: Non-supported special command %d", command));
@@ -185,7 +185,7 @@ public final class Dfu
                                          DFU_TIMEOUT);
         buffer.get(data);
         if (bytes_received < 0) {
-            LOG.info(String.format("dfuseUpload: libusb_control_transfer returned %d", bytes_received));
+            LOG.finest(String.format("dfuseUpload: libusb_control_transfer returned %d", bytes_received));
         }               
         return bytes_received;
     }
@@ -205,7 +205,7 @@ public final class Dfu
                  /* Data          */     buffer,
                                          DFU_TIMEOUT);
         if (bytes_sent < 0) {
-            LOG.info(String.format("dfuseDownload: libusb_control_transfer returned %d", bytes_sent));
+            LOG.finest(String.format("dfuseDownload: libusb_control_transfer returned %d", bytes_sent));
             return bytes_sent;
         }
         return bytes_sent;
@@ -225,7 +225,7 @@ public final class Dfu
                  status.bState != DfuStatus.STATE_DFU_MANIFEST);
 
         if (status.bState == DfuStatus.STATE_DFU_MANIFEST) {
-            LOG.info("Transitioning to dfuMANIFEST state");
+            LOG.finest("Transitioning to dfuMANIFEST state");
         }
 
         if (status.bStatus != DfuStatus.DFU_STATUS_OK) {
@@ -304,7 +304,7 @@ public final class Dfu
         DfuStatus status = new DfuStatus(null);
         while (! done) {
             status = getStatus(dev);
-            LOG.fine(String.format("Determining device status: state=%s status=%d",
+            LOG.finer(String.format("Determining device status: state=%s status=%d",
                           status.stateToString(), status.bStatus));
 
             switch (status.bState) {
@@ -313,7 +313,7 @@ public final class Dfu
                     LOG.severe("Device still in Runtime Mode!");
                     return -1;
                 case DfuStatus.STATE_DFU_ERROR:
-                    LOG.fine("dfuERROR, clearing status");
+                    LOG.finer("dfuERROR, clearing status");
                     if (clearStatus(dev) < 0) {
                         LOG.severe("error clear_status");
                         return -1;
@@ -321,14 +321,14 @@ public final class Dfu
                     break;
                 case DfuStatus.STATE_DFU_DOWNLOAD_IDLE:
                 case DfuStatus.STATE_DFU_UPLOAD_IDLE:
-                    LOG.fine("aborting previous incomplete transfer");
+                    LOG.finer("aborting previous incomplete transfer");
                     if (abort(dev) < 0) {
                         LOG.severe("can't send DFU_ABORT");
                         return -1;
                     }
                     break;
                 case DfuStatus.STATE_DFU_IDLE:
-                    LOG.fine("dfuIDLE, continuing");
+                    LOG.finer("dfuIDLE, continuing");
                     done = true;
                     break;
             }
@@ -358,8 +358,8 @@ public final class Dfu
         /* Boot loader decides the start address, unknown to us */
         /* Use a short length to lower risk of running out of bounds */
 
-        LOG.fine(String.format("bytes_per_hash=%d", xfer_size));
-        LOG.info("Starting device read");
+        LOG.finest(String.format("bytes_per_hash=%d", xfer_size));
+        LOG.finest("Starting device read");
 
         ByteArrayOutputStream data = new ByteArrayOutputStream();
         while (true) {
@@ -393,7 +393,7 @@ public final class Dfu
         setIdle(dev);
         while (true) {
             Sector sector = dev.Memory().find(sector_address);
-            LOG.info(String.format("%d: %d (%d)", sector_address, sector == null ? -1 : sector.end(), address + data.length));
+            LOG.fine(String.format("%d: %d (%d)", sector_address, sector == null ? -1 : sector.end(), address + data.length));
             if (sector == null || ! sector.writable()) {
                 LOG.severe(String.format("Error: No sector found that can be written at address 0x%08x", sector_address));
                 return -1;
@@ -424,7 +424,7 @@ public final class Dfu
                 }
             }
             if (sector.erasable()) {
-                LOG.info(String.format("Erasing page: 0x%x", sector_address));
+                LOG.fine(String.format("Erasing page: 0x%x", sector_address));
                 if (dfuseSpecialCommand(dev, sector_address, DFUSE_ERASE_PAGE) != 0) {
                     LOG.severe(String.format("Error: Write failed to erase address: 0x%x", sector_address));
                     return -1;
@@ -479,7 +479,7 @@ public final class Dfu
     }
     public static int resetSTM32(DfuDevice dev) {
     	DfuStatus status = new DfuStatus(null);
-      LOG.info("Resetting STM32, starting firmware at address 0x08000000...");
+      LOG.finest("Resetting STM32, starting firmware at address 0x08000000...");
     	int set_ret = dfuseSpecialCommand(dev, 0x08000000, DFUSE_SET_ADDRESS);
     	if( set_ret < 0 ) {
           LOG.severe("Error: Unable to set start address for resetting");
@@ -497,7 +497,7 @@ public final class Dfu
     	if( status.bState != DfuStatus.STATE_DFU_MANIFEST) {
         LOG.severe("Error: Expected STM32 to be in dfuMANIFEST state after get-status command!");
     	} else {
-          LOG.info("Successfully reset STM32");
+          LOG.finest("Successfully reset STM32");
     	}
     	return 0;
     }

--- a/src/deviation/TxInfo.java
+++ b/src/deviation/TxInfo.java
@@ -28,7 +28,7 @@ public class TxInfo {
         int j;
         for (j = 0; j < 32 && data[j] != 0; j++) { }
         model = new String(Arrays.copyOfRange(data, 0, j));
-        LOG.info(model);
+        LOG.finest(model);
         type = TransmitterList.UNKNOWN();
         txloop:
         for (Transmitter tx : TransmitterList.values()) {

--- a/src/deviation/filesystem/FlashIO.java
+++ b/src/deviation/filesystem/FlashIO.java
@@ -72,7 +72,7 @@ public class FlashIO implements BlockDevice
             	Range range = sectorMap.get(sector_num);
             	byte [] data = Arrays.copyOfRange(ram, (int)(range.start() - memAddress),  (int)(1 + range.end() - memAddress));
             	String newchksum = Sha.md5(data);
-            	LOG.info(String.format("0x%08x Read: %s Write: %s", range.start(), chksum[sector_num], newchksum));
+            	LOG.finest(String.format("0x%08x Read: %s Write: %s", range.start(), chksum[sector_num], newchksum));
             	if (chksum[sector_num] != null && chksum[sector_num].equals(newchksum)) {
             		//Data hasn't changed, no need to write it out
             		continue;
@@ -86,7 +86,7 @@ public class FlashIO implements BlockDevice
             }
     	}
     }
-    public void flush() { LOG.info("flush");}
+    public void flush() { LOG.finest("flush");}
     public int getSectorSize() throws IOException { return fsSectorSize; }
     public long getSize() throws IOException { return ram.length - startOffset; }
     public boolean isClosed() { return false; }
@@ -116,14 +116,14 @@ public class FlashIO implements BlockDevice
     */
     private void cache(int sector_num) {
     	Range range = sectorMap.get(sector_num);
-        LOG.info(String.format(("Cache of 0x%08x : %d"), range.start(), cached[sector_num] ? 1 : 0));
+        LOG.finest(String.format(("Cache of 0x%08x : %d"), range.start(), cached[sector_num] ? 1 : 0));
         if (! cached[sector_num]) {
         	final long startTime = System.currentTimeMillis();
             byte[] data = Dfu.fetchFromDevice(dev, range.start(), (int)range.size());
             final long endTime = System.currentTimeMillis();
             totalBytes += range.size();
             totalTime += endTime - startTime;
-            LOG.info(String.format("Bytes/sec: %.6f Avg: %.6f", 1000.0 *range.size()/(endTime - startTime), 1000.0*totalBytes/totalTime));
+            LOG.finest(String.format("Bytes/sec: %.6f Avg: %.6f", 1000.0 *range.size()/(endTime - startTime), 1000.0*totalBytes/totalTime));
             if (invert) {
                 data = FSUtils.invert(data);
             }

--- a/src/deviation/filesystem/TxInterfaceCommon.java
+++ b/src/deviation/filesystem/TxInterfaceCommon.java
@@ -23,11 +23,11 @@ public class TxInterfaceCommon {
     		if (entry.isDirectory()) {
     			if (entry.getName().equals(".") || entry.getName().equals(".."))
     				continue;
-    			LOG.fine(String.format("DIR: %s", entry.getName()));
+    			LOG.finest(String.format("DIR: %s", entry.getName()));
     			files.addAll(readDirRecur(parent + entry.getName() + "/", entry.getDirectory()));
     		} else {
     			files.add(new FileInfo(parent + entry.getName(), (int)entry.getFile().getLength()));
-					LOG.fine(String.format("FILE: %s (%d)", entry.getName(), entry.getFile().getLength()));
+					LOG.finest(String.format("FILE: %s (%d)", entry.getName(), entry.getFile().getLength()));
     		}
     	}
     	return files;
@@ -45,7 +45,7 @@ public class TxInterfaceCommon {
         	Iterator<FsDirectoryEntry> itr = dir.iterator();
         	while(itr.hasNext()) {
         		FsDirectoryEntry entry = itr.next();
-        		LOG.info(entry.getName());
+        		LOG.finest(entry.getName());
         	}
         } catch (IOException e) { e.printStackTrace(); }
     }

--- a/src/deviation/filesystem/TxInterfaceUSB.java
+++ b/src/deviation/filesystem/TxInterfaceUSB.java
@@ -50,7 +50,7 @@ public class TxInterfaceUSB extends TxInterfaceCommon implements TxInterface  {
         }
 		rootIface = dev.SelectInterfaceByAddr(tx.getRootSectorOffset() * SECTOR_SIZE);
 		if (rootIface == null) {
-			LOG.info("Could not identify any memory region for rootFS");
+			LOG.finest("Could not identify any memory region for rootFS");
 		}
         rootBlockDev = new FlashIO(dev, tx.getRootSectorOffset() * SECTOR_SIZE, tx.isRootInverted(), SECTOR_SIZE, null);
     	

--- a/src/deviation/gui/FileMgrTab.java
+++ b/src/deviation/gui/FileMgrTab.java
@@ -158,9 +158,9 @@ public class FileMgrTab extends JPanel {
 					} catch (Exception e) { e.printStackTrace(); }
 					List <FileInfo> files = fs.readAllDirs();
 					fs.close();
-					LOG.info(String.format("Count: %d", files.size()));
+					LOG.finest(String.format("Count: %d", files.size()));
 					for (FileInfo file: files) {
-						LOG.info("FILE: " + file.name());
+						LOG.finest("FILE: " + file.name());
 					}
 					return files;
 				}

--- a/src/deviation/gui/MonitorUSB.java
+++ b/src/deviation/gui/MonitorUSB.java
@@ -59,7 +59,7 @@ public class MonitorUSB extends SwingWorker<String, DfuDevice> {
     					if (dfuDev != null) {
     						LibUsb.freeDeviceList(this.devices, true);
     						dfuDev = null;
-    						LOG.info("Unplug detected");
+    						LOG.finest("Unplug detected");
     						state_changed = true;
     						//Signal disconnect
     					}
@@ -71,7 +71,7 @@ public class MonitorUSB extends SwingWorker<String, DfuDevice> {
     						dfuDev = dev;
     						dfuDev.setTxInfo(TxInfo.getTxInfo(dfuDev));
     						this.devices = devices;
-								LOG.info("Hotplug detected");
+								LOG.finest("Hotplug detected");
     						state_changed = true;
     						//Signal connect/change
     					} else {

--- a/src/deviation/gui/TextEditor.java
+++ b/src/deviation/gui/TextEditor.java
@@ -73,7 +73,7 @@ public class TextEditor extends JDialog implements SearchListener {
 		textArea.setMarkOccurrences(true);
 		textArea.append(finalData);
 		Font f = textArea.getFont();
-		LOG.info(String.format("Font: %d", f.getSize()));
+		LOG.finest(String.format("Font: %d", f.getSize()));
 		f = new Font(f.getFamily(), f.getStyle(), f.getSize()+5);
 		textArea.setFont(f);
 		RTextScrollPane sp = new RTextScrollPane(textArea);


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | enclosing method | type FQN | original level | new level | DOI value
-- | -- | -- | -- | -- | --
LOG.info(String.format("Erasing page: 0x%x",sector_address)) | sendToDevice(deviation.DfuDevice,long,byte[],deviation.Progress) | deviation.Dfu | INFO | FINE | 7.056999
LOG.info(String.format("%d: %d (%d)",sector_address,sector == null ? -1 : sector.end(),address + data.length)) | sendToDevice(deviation.DfuDevice,long,byte[],deviation.Progress) | deviation.Dfu | INFO | FINE | 7.056999
LOG.info(String.format("Setting address pointer to 0x%x",address)) | dfuseSpecialCommand(deviation.DfuDevice,long,int) | deviation.Dfu | INFO | FINE | 6.0169983
LOG.fine(String.format("Determining device status: state=%s status=%d",status.stateToString(),status.bStatus)) | setIdle(deviation.DfuDevice) | deviation.Dfu | FINE | FINER | 4.412998
LOG.fine("dfuERROR, clearing status") | setIdle(deviation.DfuDevice) | deviation.Dfu | FINE | FINER | 4.412998
LOG.fine("dfuIDLE, continuing") | setIdle(deviation.DfuDevice) | deviation.Dfu | FINE | FINER | 4.412998
LOG.fine("aborting previous incomplete transfer") | setIdle(deviation.DfuDevice) | deviation.Dfu | FINE | FINER | 4.412998
LOG.info("Successfully reset STM32") | resetSTM32(deviation.DfuDevice) | deviation.Dfu | INFO | FINEST | 2.038
LOG.info("Resetting STM32, starting firmware at address 0x08000000...") | resetSTM32(deviation.DfuDevice) | deviation.Dfu | INFO | FINEST | 2.038
LOG.fine(String.format("FILE: %s (%d)",entry.getName(),entry.getFile().getLength())) | readDirRecur(java.lang.String,de.waldheinz.fs.FsDirectory) | deviation.filesystem.TxInterfaceCommon | FINE | FINEST | 1.5049992
LOG.fine(String.format("DIR: %s",entry.getName())) | readDirRecur(java.lang.String,de.waldheinz.fs.FsDirectory) | deviation.filesystem.TxInterfaceCommon | FINE | FINEST | 1.5049992
LOG.info(String.format(("Cache of 0x%08x : %d"),range.start(),cached[sector_num] ? 1 : 0)) | cache(int) | deviation.filesystem.FlashIO | INFO | FINEST | 1.4370003
LOG.info(String.format("Bytes/sec: %.6f Avg: %.6f",1000.0 * range.size() / (endTime - startTime),1000.0 * totalBytes / totalTime)) | cache(int) | deviation.filesystem.FlashIO | INFO | FINEST | 1.4370003
LOG.info("Hotplug detected") | doInBackground() | deviation.gui.MonitorUSB | INFO | FINEST | 1.1620007
LOG.info("Unplug detected") | doInBackground() | deviation.gui.MonitorUSB | INFO | FINEST | 1.1620007
LOG.info("FILE: " + file.name()) | doInBackground() | deviation.gui.FileMgrTab | INFO | FINEST | 1.0599995
LOG.info(String.format("Count: %d",files.size())) | doInBackground() | deviation.gui.FileMgrTab | INFO | FINEST | 1.0599995
LOG.info(String.format("Font: %d",f.getSize())) | TextEditor(deviation.FileInfo) | deviation.gui.TextEditor | INFO | FINEST | 0.4959998
LOG.info("Transitioning to dfuMANIFEST state") | dfuseDownloadChunk(deviation.DfuDevice,byte[],int) | deviation.Dfu | INFO | FINEST | 0.36600113
LOG.info("Could not identify any memory region for rootFS") | TxInterfaceUSB(deviation.DfuDevice) | deviation.filesystem.TxInterfaceUSB | INFO | FINEST | 0.20699978
LOG.info(entry.getName()) | readDir(de.waldheinz.fs.FileSystem,java.lang.String) | deviation.filesystem.TxInterfaceCommon | INFO | FINEST | 0.087999344
LOG.info("flush") | flush() | deviation.filesystem.FlashIO | INFO | FINEST | 0.019999504
LOG.info(String.format("0x%08x Read: %s Write: %s",range.start(),chksum[sector_num],newchksum)) | close() | deviation.filesystem.FlashIO | INFO | FINEST | 0.002998352
LOG.info(String.format("dfuseUpload: libusb_control_transfer returned %d",bytes_received)) | dfuseUpload(deviation.DfuDevice,byte[],int) | deviation.Dfu | INFO | FINEST | 0
LOG.info("Starting device read") | fetchFromDevice(deviation.DfuDevice,long,int) | deviation.Dfu | INFO | FINEST | 0
LOG.info("No devices found.") | listDevices(java.util.List) | deviation.DeviationUploader | INFO | FINEST | 0
LOG.info(model) | TxInfo(byte[]) | deviation.TxInfo | INFO | FINEST | 0
LOG.info(String.format("dfuseDownload: libusb_control_transfer returned %d",bytes_sent)) | dfuseDownload(deviation.DfuDevice,byte[],int) | deviation.Dfu | INFO | FINEST | 0
LOG.info(String.format("%s",dev.getTxInfo().type().getName())) | listDevices(java.util.List) | deviation.DeviationUploader | INFO | FINEST | 0
LOG.info("Encrypting txid for " + TxInfo.typeToString(info.type())) | applyEncryption(deviation.DfuFile.ImageElement,deviation.TxInfo) | deviation.DeviationUploader | INFO | FINEST | 0
LOG.fine(String.format("bytes_per_hash=%d",xfer_size)) | fetchFromDevice(deviation.DfuDevice,long,int) | deviation.Dfu | FINE | FINEST | 0
LOG.info(String.format("\t\t%d %08x   %08x %7d   %d",i,sector.start(),sector.end(),sector.size(),sector.count())) | listDevices(java.util.List) | deviation.DeviationUploader | INFO | FINEST | 0
LOG.info(String.format("Device\t%9s %8s   %8s %7s   %s","Interface","Start","End","Size","Count")) | listDevices(java.util.List) | deviation.DeviationUploader | INFO | FINEST | 0

## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG/WARNING/SEVERE level as a category and not a traditional level, i.e., our tool ignores CONFIG/WARNING/SEVERE log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The greatest number of commits evaluated: 300 (setting 3).

Head: 88751d6d7f082ec6649cbae4bb3dc2e717db60a3

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

low boundary inclusive | high boundary exclusive | log level
-- | -- | --
0 | 2.90875 | FINEST
2.90875 | 5.8175 | FINER
5.8175 | 8.72625 | FINE
8.72625 | 11.635 | INFO