### PR TITLE
Rejuvenate log levels using setting 2

### DIFF
--- a/src/deviation/DeviationUploader.java
+++ b/src/deviation/DeviationUploader.java
@@ -167,12 +167,12 @@ public class DeviationUploader
     private static void listDevices(List <DfuDevice> devs)
     {
       if (devs.size() == 0) {
-        LOG.info("No devices found.");
+        LOG.fine("No devices found.");
       } else {
         LOG.info(String.format("Device\t%9s %8s   %8s %7s   %s", "Interface", "Start", "End", "Size", "Count"));
         for (DfuDevice dev: devs) {
           int i = 0;
-          LOG.info(String.format("%s", dev.getTxInfo().type().getName()));
+          LOG.fine(String.format("%s", dev.getTxInfo().type().getName()));
           for (DfuInterface iface: dev.Interfaces()) {
             for (SegmentParser segment: iface.Memory().segments()) {
               for (Sector sector: segment.sectors()) {

--- a/src/deviation/Dfu.java
+++ b/src/deviation/Dfu.java
@@ -313,7 +313,7 @@ public final class Dfu
                     LOG.severe("Device still in Runtime Mode!");
                     return -1;
                 case DfuStatus.STATE_DFU_ERROR:
-                    LOG.fine("dfuERROR, clearing status");
+                    LOG.warning("dfuERROR, clearing status");
                     if (clearStatus(dev) < 0) {
                         LOG.severe("error clear_status");
                         return -1;

--- a/src/deviation/ZipFile.java
+++ b/src/deviation/ZipFile.java
@@ -38,7 +38,7 @@ public class ZipFile {
                 }
                 ostream.flush();
                 if (ostream.size() != ze.getSize()) {
-                    LOG.warning(String.format("Only read %d bytes from %s:%s (expected %d)", ostream.size(), zipFile, fname, ze.getSize()));
+                    LOG.info(String.format("Only read %d bytes from %s:%s (expected %d)", ostream.size(), zipFile, fname, ze.getSize()));
                 } else {
                     buffer = ostream.toByteArray();
                 }
@@ -69,7 +69,7 @@ public class ZipFile {
                  }
                  ostream.flush();
                  if (ostream.size() != ze.getSize()) {
-                     LOG.warning(String.format("Only read %d bytes from %s:%s (expected %d)", ostream.size(), zipFile, fname, ze.getSize()));
+                     LOG.info(String.format("Only read %d bytes from %s:%s (expected %d)", ostream.size(), zipFile, fname, ze.getSize()));
                  } else {
                      buffer = ostream.toByteArray();
                  }

--- a/src/deviation/filesystem/FlashIO.java
+++ b/src/deviation/filesystem/FlashIO.java
@@ -86,7 +86,7 @@ public class FlashIO implements BlockDevice
             }
     	}
     }
-    public void flush() { LOG.info("flush");}
+    public void flush() { LOG.finer("flush");}
     public int getSectorSize() throws IOException { return fsSectorSize; }
     public long getSize() throws IOException { return ram.length - startOffset; }
     public boolean isClosed() { return false; }

--- a/src/deviation/filesystem/TxInterfaceCommon.java
+++ b/src/deviation/filesystem/TxInterfaceCommon.java
@@ -23,11 +23,11 @@ public class TxInterfaceCommon {
     		if (entry.isDirectory()) {
     			if (entry.getName().equals(".") || entry.getName().equals(".."))
     				continue;
-    			LOG.fine(String.format("DIR: %s", entry.getName()));
+    			LOG.finer(String.format("DIR: %s", entry.getName()));
     			files.addAll(readDirRecur(parent + entry.getName() + "/", entry.getDirectory()));
     		} else {
     			files.add(new FileInfo(parent + entry.getName(), (int)entry.getFile().getLength()));
-					LOG.fine(String.format("FILE: %s (%d)", entry.getName(), entry.getFile().getLength()));
+					LOG.finer(String.format("FILE: %s (%d)", entry.getName(), entry.getFile().getLength()));
     		}
     	}
     	return files;
@@ -45,7 +45,7 @@ public class TxInterfaceCommon {
         	Iterator<FsDirectoryEntry> itr = dir.iterator();
         	while(itr.hasNext()) {
         		FsDirectoryEntry entry = itr.next();
-        		LOG.info(entry.getName());
+        		LOG.finer(entry.getName());
         	}
         } catch (IOException e) { e.printStackTrace(); }
     }

--- a/src/deviation/gui/MonitorUSB.java
+++ b/src/deviation/gui/MonitorUSB.java
@@ -59,7 +59,7 @@ public class MonitorUSB extends SwingWorker<String, DfuDevice> {
     					if (dfuDev != null) {
     						LibUsb.freeDeviceList(this.devices, true);
     						dfuDev = null;
-    						LOG.info("Unplug detected");
+    						LOG.finer("Unplug detected");
     						state_changed = true;
     						//Signal disconnect
     					}
@@ -71,7 +71,7 @@ public class MonitorUSB extends SwingWorker<String, DfuDevice> {
     						dfuDev = dev;
     						dfuDev.setTxInfo(TxInfo.getTxInfo(dfuDev));
     						this.devices = devices;
-								LOG.info("Hotplug detected");
+								LOG.finer("Hotplug detected");
     						state_changed = true;
     						//Signal connect/change
     					} else {

--- a/src/deviation/gui/TextEditor.java
+++ b/src/deviation/gui/TextEditor.java
@@ -73,7 +73,7 @@ public class TextEditor extends JDialog implements SearchListener {
 		textArea.setMarkOccurrences(true);
 		textArea.append(finalData);
 		Font f = textArea.getFont();
-		LOG.info(String.format("Font: %d", f.getSize()));
+		LOG.finer(String.format("Font: %d", f.getSize()));
 		f = new Font(f.getFamily(), f.getStyle(), f.getSize()+5);
 		textArea.setFont(f);
 		RTextScrollPane sp = new RTextScrollPane(textArea);


### PR DESCRIPTION
Here's a reissue of https://github.com/DeviationTX/deviation-upload/pull/14 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 88751d6d7f082ec6649cbae4bb3dc2e717db60a3